### PR TITLE
Z-index for ng-outer-menu

### DIFF
--- a/src/ng-select/ng-select.component.scss
+++ b/src/ng-select/ng-select.component.scss
@@ -222,7 +222,7 @@ ng-select {
         position: absolute;
         top: 100%;
         width: 100%;
-        z-index: 1;
+        z-index: 3;
         -webkit-overflow-scrolling: touch;
     }
     .ng-menu {


### PR DESCRIPTION
Changed the z-index of ng-outer-menu to 3, so that it remains always visible when opened on top of a .input-group.form-control element.  .input-group .form-control has a z-index of 2 and thus was visible on top of the dropdown