### PR TITLE
fix: setTouched on Select Close instead of Open

### DIFF
--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -276,7 +276,6 @@ export class NgSelectComponent implements OnInit, OnDestroy, OnChanges, AfterVie
         this.itemsList.markSelectedOrDefault(this.markFirst);
         this._scrollToMarked();
         this._focusSearchInput();
-        this._onTouched();
         this.openEvent.emit();
         if (this.appendTo) {
             this._updateDropdownPosition();
@@ -289,6 +288,7 @@ export class NgSelectComponent implements OnInit, OnDestroy, OnChanges, AfterVie
         }
         this.isOpen = false;
         this._clearSearch();
+        this._onTouched();
         this.closeEvent.emit();
     }
 


### PR DESCRIPTION
This will set `touched` on closing the option instead of open.

A typical HTML Select in Angular will set touched once the user
mouse clicks out or tabs (keyboard) out. This will emulate that
same behaviour. Setting `touched` right away on open causes
weird user experience when displaying error message that 
typically depend on `touched` being set. We want to let
the user interact with the select and once done interaction,
it is to be set `touched`.

PR Closes #225. A modification to the change in PR #228.

Would greatly appreciate if you can include in this a new version or recut version `0.17.0` with this included this PR is accepted. Awesome job on this great library 👍 

/cc @anjmao 