### PR TITLE
Don't show notFoundText when async operation is still loading

### DIFF
--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -366,7 +366,7 @@ export class NgSelectComponent implements OnInit, OnDestroy, OnChanges, AfterVie
 
     showNoItemsFound() {
         const empty = this.itemsList.filteredItems.length === 0;
-        return (empty && !this._isTypeahead) ||
+        return (empty && !this._isTypeahead && !this.isLoading) ||
             (empty && this._isTypeahead && this.filterValue && !this.isLoading);
     }
 


### PR DESCRIPTION
Addresses https://github.com/ng-select/ng-select/issues/243