### PR TITLE
fix(template): fix AOT compile error

### DIFF
--- a/src/ng-select/ng-select.component.html
+++ b/src/ng-select/ng-select.component.html
@@ -19,8 +19,8 @@
                    [readOnly]="!searchable"
                    [value]="filterValue"
                    (input)="onFilter(filterInput.value)"
-                   (focus)="onInputFocus($event)"
-                   (blur)="onInputBlur($event)"
+                   (focus)="onInputFocus()"
+                   (blur)="onInputBlur()"
                    (change)="$event.stopPropagation()"
                    role="combobox">
         </div>


### PR DESCRIPTION
These two functions don't take any arguments, so when using `fullTemplateTypeCheck` with AOT compiler, it will fail because the argument count does not match. 