### PR TITLE
fix: Mouse events interfering with virtual scroll (#260)

### DIFF
--- a/src/ng-select/ng-select.component.html
+++ b/src/ng-select/ng-select.component.html
@@ -42,7 +42,7 @@
         <ng-container [ngTemplateOutlet]="headerTemplate"></ng-container>
     </div>
     <ng-select-virtual-scroll class="ng-select-dropdown" [disabled]="disableVirtualScroll" [bufferAmount]="4" [items]="itemsList.filteredItems" (update)="viewPortItems = $event">
-        <div class="ng-option" role="option" (click)="toggleItem(item)" (mousedown)="$event.preventDefault()" (mouseover)="onItemHover(item)"
+        <div class="ng-option" role="option" (click)="toggleItem(item)" (mousedown)="$event.preventDefault()" (mouseover)="onItemHover(item)" (mousemove)="onMouseMove()"
              *ngFor="let item of viewPortItems"
              [class.disabled]="item.disabled"
              [class.selected]="item.selected"

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -121,6 +121,7 @@ export class NgSelectComponent implements OnInit, OnDestroy, OnChanges, AfterVie
     private _defaultLabel = 'label';
     private _defaultValue = 'value';
     private _typeaheadLoading = false;
+    private _navigatingWithKeys = false;
 
     private _onChange = (_: NgOption) => { };
     private _onTouched = () => { };
@@ -188,9 +189,11 @@ export class NgSelectComponent implements OnInit, OnDestroy, OnChanges, AfterVie
         if (KeyCode[$event.which]) {
             switch ($event.which) {
                 case KeyCode.ArrowDown:
+                    this._navigatingWithKeys = true;
                     this._handleArrowDown($event);
                     break;
                 case KeyCode.ArrowUp:
+                    this._navigatingWithKeys = true;
                     this._handleArrowUp($event);
                     break;
                 case KeyCode.Space:
@@ -398,10 +401,14 @@ export class NgSelectComponent implements OnInit, OnDestroy, OnChanges, AfterVie
     }
 
     onItemHover(item: NgOption) {
-        if (item.disabled) {
+        if (item.disabled || this._navigatingWithKeys) {
             return;
         }
         this.itemsList.markItem(item);
+    }
+
+    onMouseMove() {
+        this._navigatingWithKeys = false;
     }
 
     detectChanges() {


### PR DESCRIPTION
This is a suggested fix for #260 . Mouse hover events will be ignored as long as one of the key up or down keys is pressed.