### PR TITLE
Add change detection after disable

### DIFF
--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -1429,6 +1429,17 @@ describe('NgSelectComponent', function () {
             tickAndDetectChanges(fixture);
             expect(fixture.componentInstance.select.isOpen).toBe(false);
         }));
+
+        it('clear button should not appear if select is disabled', fakeAsync(() => {            
+            fixture.componentInstance.selectedCity = fixture.componentInstance.cities[0];
+            tickAndDetectChanges(fixture);
+
+            fixture.componentInstance.select.setDisabledState(true);            
+            tickAndDetectChanges(fixture);
+            
+            const el = fixture.debugElement.query(By.css('.ng-clear-zone'));
+            expect(el).toBeNull();
+        }));
     });
 
     describe('Arrow icon click', () => {

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -268,6 +268,7 @@ export class NgSelectComponent implements OnInit, OnDestroy, OnChanges, AfterVie
 
     setDisabledState(isDisabled: boolean): void {
         this.isDisabled = isDisabled;
+        this.detectChanges();
     }
 
     toggle() {


### PR DESCRIPTION
Hi,

Bug : When toggle select to disable, the clear button still appear. 

Test case : 
- Go to : https://ng-select.github.io/ng-select#/forms
- Select an Age on select
- Click on Toggle disable button
Result : The clear button is not hide.

If you click on the select (not on the clear button), state is refresh and button disappears.

Fix : just trigger change detector on setDisabledState.

Regards. 
