### PR TITLE
fix: incorrect border on multiple default theme (#354)

### DIFF
--- a/src/themes/default.theme.scss
+++ b/src/themes/default.theme.scss
@@ -96,9 +96,11 @@ $color-selected: #f5faff;
                         border: 1px solid #e3e3e3;
                     }
                     .ng-value-label {
+                        display: inline-block;
                         padding: 2px 5px 2px 1px;
                     }
                     .ng-value-icon {
+                        display: inline-block;
                         padding: 3px 5px;
                         &:hover {
                             background-color: #d8eafd;


### PR DESCRIPTION
Resolves #354 by adding `display: inline-block;` to `.ng-value-icon` and `.ng-value-item` of multiple default theme.