### PR TITLE
Fix performance issue with function and filter

### DIFF
--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -193,9 +193,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     ngAfterViewInit() {
-        if (this.ngOptions.length > 0 && this.items.length === 0) {
-            this._setItemsFromNgOptions();
-        }
+        this._setItemsFromNgOptions();
     }
 
     ngOnDestroy() {

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -187,13 +187,17 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         if (changes.multiple) {
             this.itemsList.clearSelected();
         }
-        if (changes.items) {
+        if (changes.items && 
+            (changes.items.firstChange || 
+            (!changes.items.firstChange && changes.items.currentValue.length !== changes.items.previousValue.length))) {
             this._setItems(changes.items.currentValue || []);
         }
     }
 
     ngAfterViewInit() {
-        this._setItemsFromNgOptions();
+        if (this.ngOptions.length > 0 && this.items.length === 0) {
+            this._setItemsFromNgOptions();
+        }
     }
 
     ngOnDestroy() {
@@ -455,6 +459,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     private _setItems(items: any[]) {
+        console.log('selectSetItems');
         const firstItem = items[0];
         this.bindLabel = this.bindLabel || this._defaultLabel;
         this._primitive = !isObject(firstItem);

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -459,7 +459,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     private _setItems(items: any[]) {
-        console.log('selectSetItems');
         const firstItem = items[0];
         this.bindLabel = this.bindLabel || this._defaultLabel;
         this._primitive = !isObject(firstItem);


### PR DESCRIPTION
This fixes performance issue, shouldn't update the items on every change detection, its way too slow. This can be seen when you add a simple filter such as .filter(a => a > 5). Only set the items when the length changes.