### PR TITLE
Fix for only 1 ng-container that populates after ngAfterViewInit is ran

### DIFF
--- a/demo/app/examples/data-source.component.ts
+++ b/demo/app/examples/data-source.component.ts
@@ -74,6 +74,19 @@ import { Observable } from 'rxjs/Observable';
         </ng-select>
         ---
         <br />Selected car ID: {{selectedCarId | json}}
+        <hr />
+        <p>
+            Filling ng options after ngAfterViewInit
+        </p>
+        <button type="button" class="btn btn-secondary btn-sm" (click)="toggleDisabled()">Toggle disabled</button>
+        <hr/>
+        ---html,true
+        <ng-select>
+            <ng-option *ngFor="let test of testData" [value]="test.id">{{test.name}}</ng-option>
+        </ng-select>
+        ---
+        <br />
+        <button type="button" class="btn btn-primary btn-sm" (click)="popTestData()">Populate Test Data</button>
     `
 })
 export class DataSourceComponent {
@@ -85,6 +98,8 @@ export class DataSourceComponent {
     selectedSimpleItem = 'Two';
     simpleItems = [];
     disable = true;
+
+    testData = [];
 
     selectedCarId = 3;
     cars = [
@@ -105,6 +120,14 @@ export class DataSourceComponent {
     toggleDisabled() {
         const car: any = this.cars[1];
         car.disabled = !car.disabled;
+    }
+
+    popTestData() {
+        this.testData = [];
+
+        for (let i = 0; i < 5; i++) {
+            this.testData.push({id: i, name: i});
+        }
     }
 }
 

--- a/demo/app/examples/data-source.component.ts
+++ b/demo/app/examples/data-source.component.ts
@@ -74,19 +74,6 @@ import { Observable } from 'rxjs/Observable';
         </ng-select>
         ---
         <br />Selected car ID: {{selectedCarId | json}}
-        <hr />
-        <p>
-            Filling ng options after ngAfterViewInit
-        </p>
-        <button type="button" class="btn btn-secondary btn-sm" (click)="toggleDisabled()">Toggle disabled</button>
-        <hr/>
-        ---html,true
-        <ng-select>
-            <ng-option *ngFor="let test of testData" [value]="test.id">{{test.name}}</ng-option>
-        </ng-select>
-        ---
-        <br />
-        <button type="button" class="btn btn-primary btn-sm" (click)="popTestData()">Populate Test Data</button>
     `
 })
 export class DataSourceComponent {
@@ -98,8 +85,6 @@ export class DataSourceComponent {
     selectedSimpleItem = 'Two';
     simpleItems = [];
     disable = true;
-
-    testData = [];
 
     selectedCarId = 3;
     cars = [
@@ -120,14 +105,6 @@ export class DataSourceComponent {
     toggleDisabled() {
         const car: any = this.cars[1];
         car.disabled = !car.disabled;
-    }
-
-    popTestData() {
-        this.testData = [];
-
-        for (let i = 0; i < 5; i++) {
-            this.testData.push({id: i, name: i});
-        }
     }
 }
 

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -196,12 +196,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     ngAfterViewInit() {
-        // Old Way
-        // if (this.ngOptions.length > 0 && this.items.length === 0) {
-        //     this._setItemsFromNgOptions();
-        // }
-
-        // New Way
         if (this.items && this.items.length === 0) {
             this._setItemsFromNgOptions();
         }

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -196,7 +196,13 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     ngAfterViewInit() {
-        if (this.ngOptions.length >= 0 && this.items.length === 0) {
+        // Old Way
+        // if (this.ngOptions.length > 0 && this.items.length === 0) {
+        //     this._setItemsFromNgOptions();
+        // }
+
+        // New Way
+        if (this.items && this.items.length === 0) {
             this._setItemsFromNgOptions();
         }
     }

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -196,7 +196,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     ngAfterViewInit() {
-        if (this.ngOptions.length > 0 && this.items.length === 0) {
+        if (this.ngOptions.length >= 0 && this.items.length === 0) {
             this._setItemsFromNgOptions();
         }
     }


### PR DESCRIPTION
Fixes and passes tests for the ng-option bug when the ng-option is populated after the ngAfterViewInit has ran.