### PR TITLE
feat: add support for label "for" attribute

### DIFF
--- a/demo/app/examples/reactive-forms.component.ts
+++ b/demo/app/examples/reactive-forms.component.ts
@@ -41,11 +41,13 @@ import { delay } from 'rxjs/operators';
             </div>
             <hr>
             <div class="form-group">
-                <label for="state">Single select</label>
+                <label>Single select</label>
                 ---html,true
+                <label for="age">Age</label>
                 <ng-select #agesSelect [items]="ages"
                         [selectOnTab]="true"
                         bindValue="value"
+                        labelForId="age"
                         (ngModelChange)="showConfirm()"
                         placeholder="Select age"
                         formControlName="age">

--- a/src/ng-select/ng-select.component.html
+++ b/src/ng-select/ng-select.component.html
@@ -36,6 +36,7 @@
                    *ngIf="searchable"
                    type="text"
                    autocomplete="{{dropdownId}}"
+                   [id]="labelForId"
                    [value]="filterValue"
                    (input)="filter(filterInput.value)"
                    (focus)="onInputFocus()"

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -98,6 +98,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() selectableGroup = false;
     @Input() searchFn = null;
     @Input() clearSearchOnAdd = true;
+    @Input() labelForId: string;
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;
     @Input() @HostBinding('class.ng-select-taggable') addTag: boolean | AddTagFn = false;


### PR DESCRIPTION
This allows to associate label with ng-select using label "for" attribute. It adds id on input element since control itself can not be labelable. More on it https://www.w3.org/TR/html5/forms.html#category-label
closes #537