### PR TITLE
Bugfix: keep filter status consistent with items updates

### DIFF
--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -2039,6 +2039,42 @@ describe('NgSelectComponent', function () {
             expect(filteredItems[1].label).toBe('Adam');
         }));
 
+        it('should continue filtering items on update of items', fakeAsync(() => {
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `<ng-select [items]="cities"
+                    bindLabel="name"
+                    [(ngModel)]="selectedCity">
+                </ng-select>`);
+            tickAndDetectChanges(fixture);
+
+            fixture.componentInstance.select.filter('vil');
+            tickAndDetectChanges(fixture);
+
+            let result = [jasmine.objectContaining({
+                value: { id: 1, name: 'Vilnius' }
+            })];
+            expect(fixture.componentInstance.select.itemsList.filteredItems).toEqual(result);
+
+            fixture.componentInstance.cities = [
+                { id: 1, name: 'Vilnius' },
+                { id: 2, name: 'Kaunas' },
+                { id: 3, name: 'Pabrade' },
+                { id: 4, name: 'Bruchhausen-Vilsen' },
+            ];
+            tickAndDetectChanges(fixture);
+
+            result = [
+                jasmine.objectContaining({
+                    value: { id: 1, name: 'Vilnius' }
+                }),
+                jasmine.objectContaining({
+                    value: { id: 4, name: 'Bruchhausen-Vilsen' }
+                })
+            ];
+            expect(fixture.componentInstance.select.itemsList.filteredItems).toEqual(result);
+        }));
+
         describe('with typeahead', () => {
             let fixture: ComponentFixture<NgSelectTestCmp>
             beforeEach(() => {

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -483,7 +483,9 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         if (items.length > 0 && this.hasValue) {
             this.itemsList.mapSelectedItems();
         }
-
+        if (this.isOpen && isDefined(this.filterValue) && !this._isTypeahead) {
+            this.itemsList.filter(this.filterValue);
+        }
         if (this._isTypeahead || this.isOpen) {
             this.itemsList.markSelectedOrDefault(this.markFirst);
         }


### PR DESCRIPTION
Item list updates result in a reset of the filtered item list. This will result in an inconsistent state in case the ng-select is open while item list updates arrive.

This PR corrects the problem.