### PR TITLE
fix: make arrow-wrapper clickable

### DIFF
--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -273,7 +273,7 @@ describe('NgSelectComponent', function () {
         it('should set items correctly if there is no bindLabel', fakeAsync(() => {
             const fixture = createTestingModule(
                 NgSelectTestCmp,
-                `<ng-select 
+                `<ng-select
                     [items]="cities"
                     [clearable]="true"
                     [(ngModel)]="selectedCity">
@@ -758,7 +758,7 @@ describe('NgSelectComponent', function () {
 
                     const cmp = fixture.componentInstance;
                     cmp.selectedCityId = cmp.cities[1].id.toString();
-                   
+
                     cmp.compareWith = (city, model: string) => city.id === +model;
 
                     tickAndDetectChanges(fixture);
@@ -1471,10 +1471,10 @@ describe('NgSelectComponent', function () {
         it('should display custom loading and no data found template', fakeAsync(() => {
             const fixture = createTestingModule(
                 NgSelectTestCmp,
-                `<ng-select [items]="cities" 
+                `<ng-select [items]="cities"
                             [loading]="citiesLoading"
                             [(ngModel)]="selectedCity">
-                    
+
                     <ng-template ng-notfound-tmp let-searchTerm="searchTerm">
                         <div class="custom-notfound">
                             No data found for "{{searchTerm}}"
@@ -1509,15 +1509,15 @@ describe('NgSelectComponent', function () {
         it('should display custom type for search template', fakeAsync(() => {
             const fixture = createTestingModule(
                 NgSelectTestCmp,
-                `<ng-select [items]="cities" 
-                            [typeahead]="filter" 
+                `<ng-select [items]="cities"
+                            [typeahead]="filter"
                             [(ngModel)]="selectedCity">
                     <ng-template ng-typetosearch-tmp>
                         <div class="custom-typeforsearch">
                             Start typing...
                         </div>
                     </ng-template>
-                   
+
                 </ng-select>`);
 
             fixture.whenStable().then(() => {
@@ -2280,7 +2280,7 @@ describe('NgSelectComponent', function () {
                 NgSelectTestCmp,
                 `<ng-select [items]="cities"
                         labelForId="lbl"
-                        (change)="onChange($event)" 
+                        (change)="onChange($event)"
                         bindLabel="name">
                 </ng-select>`);
             select = fixture.componentInstance.select;
@@ -2619,7 +2619,7 @@ describe('NgSelectComponent', function () {
                 tickAndDetectChanges(fixture);
                 triggerMousedown = () => {
                     const control = fixture.debugElement.query(By.css('.ng-select-container'));
-                    control.triggerEventHandler('mousedown', createEvent({ target: { className: 'ng-arrow' } }));
+                    control.triggerEventHandler('mousedown', createEvent({ target: { className: 'ng-arrow-wrapper' } }));
                 };
             }));
 

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -256,7 +256,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             this.handleClearClick();
             return;
         }
-        if (target.className === 'ng-arrow') {
+        if (target.className === 'ng-arrow-wrapper') {
             this.handleArrowClick();
             return;
         }


### PR DESCRIPTION
The `.arrow-wrapper` has `cursor: pointer` and a larger clickable area than the inner `.arrow`, which means that it looks, but isn't entirely, clickable.

Fixes #601