### PR TITLE
Listen to `touchstart` events for outside click.

### DIFF
--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -1307,6 +1307,15 @@ describe('NgSelectComponent', function () {
             expect(fixture.componentInstance.select.isOpen).toBeFalsy();
         }));
 
+        it('should close dropdown if opened and touched outside dropdown container', fakeAsync(() => {
+            triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
+            expect(fixture.componentInstance.select.isOpen).toBeTruthy();
+            let event = new TouchEvent('touchstart', { bubbles: true });
+            document.getElementById('outside').dispatchEvent(event);
+            tickAndDetectChanges(fixture);
+            expect(fixture.componentInstance.select.isOpen).toBeFalsy();
+        }));
+
         it('should prevent dropdown close if clicked on select', fakeAsync(() => {
             triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
             expect(select.isOpen).toBeTruthy();


### PR DESCRIPTION
This allows us to dismiss dropdown panel when touching elements outside the selection menu on touch-enabled devices such as phones.