### PR TITLE
enforce height:auto on dropdown panel

### DIFF
--- a/src/themes/default.theme.scss
+++ b/src/themes/default.theme.scss
@@ -161,6 +161,7 @@ $color-selected: #f5faff;
 }
 
 .ng-dropdown-panel {
+    height: auto !important;
     background-color: #fff;
     border: 1px solid #ccc;
     box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
I had an issue with OnScrollToEnd not firing and found that the problem was caused by other general app level style rules messing with the dropdown height. Enforcing the height to auto fixed the issue. 
This new rule should keep it safe from this kind of issue.