### PR TITLE
fix: issue#620 emit addEvent after ngModel is updated

### DIFF
--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -2555,6 +2555,26 @@ describe('NgSelectComponent', function () {
             expect(fixture.componentInstance.onAdd).toHaveBeenCalledWith(fixture.componentInstance.cities[0]);
         }));
 
+        it('should updated ngModel beforeAddEvent is fired', fakeAsync(() => {
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `<ng-select [items]="cities"
+                            (add)="onAdd($event)"
+                            [multiple]="true"
+                            [(ngModel)]="selectedCity">
+                </ng-select>`);
+
+
+            expect(fixture.componentInstance.selectedCity).toBeUndefined();
+            spyOn(fixture.componentInstance, 'onAdd');
+
+            tickAndDetectChanges(fixture);
+            fixture.componentInstance.select.select(fixture.componentInstance.select.itemsList.items[0]);
+            expect(fixture.componentInstance.selectedCity).toBeDefined();
+
+            expect(fixture.componentInstance.onAdd).toHaveBeenCalledWith(fixture.componentInstance.cities[0]);
+        }));
+
         it('should not fire addEvent for single select', fakeAsync(() => {
             const fixture = createTestingModule(
                 NgSelectTestCmp,

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -399,10 +399,11 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
                 this._clearSearch();
             }
 
+            this._updateNgModel();
+
             if (this.multiple) {
                 this.addEvent.emit(item.value);
             }
-            this._updateNgModel();
         }
 
         if (this.closeOnSelect || this.itemsList.noItemsToSelect) {


### PR DESCRIPTION
I believe that this is the correct behavior to resolve issue #620 without adding a separate event.