### PR TITLE
Export `ng-templates.directive` in `index.ts`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { NgSelectComponent, NG_SELECT_DEFAULT_CONFIG, SELECTION_MODEL_FACTORY } 
 export { NgSelectModule } from './ng-select/ng-select.module';
 export { NgOption, NgSelectConfig } from './ng-select/ng-select.types';
 export { SelectionModel } from './ng-select/selection-model';
+export * from './ng-select/ng-templates.directive';


### PR DESCRIPTION
Sometimes we want use directive in our wrapper component to find current template and pass it down.

At this moment we can't import correctly.
When we import it from `@ng-select/ng-select/ng-select/ng-templates.directive`, `Angular` throws error:
`Module not found: Error: Can't resolve '@ng-select/ng-select/ng-select/ng-templates.directive' in '../project'`