### PR TITLE
Prevent clear list when pass multiple

### DIFF
--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -211,7 +211,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     ngOnChanges(changes: SimpleChanges) {
-        if (changes.multiple) {
+        if (changes.multiple && !changes.multiple.isFirstChange()) {
             this.itemsList.clearSelected();
         }
         if (changes.items) {


### PR DESCRIPTION
I pass multiple arugment value is false explicit as <ng-select [multiple]="multiple"> and sometime when I navigate to page with ng-select list is empty. If I don't pass and multiple is default false it work fine. By default and pass multiple = false expected will same behavior but it's not. Try to fixed and seems it work well