### PR TITLE
fix: ng-clear not clickable on ios safari (#856)

### DIFF
--- a/src/ng-select/ng-select.component.scss
+++ b/src/ng-select/ng-select.component.scss
@@ -69,7 +69,7 @@
                     box-shadow: none;
                     outline: none;
                     cursor: default;
-                    width: 100%;
+                    width: 75%;
                     &::-ms-clear {
                         display: none;
                     }


### PR DESCRIPTION
100% wide input seems to overlap `.ng-clear` element and captures the click.