### PR TITLE
Allow form to submit when enter is pressed on a closed ng-select

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ map: {
 | [searchFn] | `(term: string, item: any) => boolean` | `null` | no | Allow to filter by custom search function |
 | [clearSearchOnAdd] | `boolean` | `true` | no | Clears search input when item is selected. Default `true`. Default `false` when **closeOnSelect** is `false` |
 | [selectOnTab] | `boolean` | `false` | no | Select marked dropdown item using tab. Default `false`|
+| [openOnEnter] | `boolean` | `true` | no | Open dropdown using enter. Default `true`|
 | [typeahead] | `Subject` |  `-` | no | Custom autocomplete or advanced filter. |
 | typeToSearchText | `string` | `Type to search` | no | Set custom text when using Typeahead |
 | [virtualScroll] | `boolean` |  false | no | Enable virtual scroll for better performance when rendering a lot of data |

--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -1312,6 +1312,12 @@ describe('NgSelectComponent', function () {
                 expect(select.selectedItems[0].value).toEqual(fixture.componentInstance.cities[0]);
                 expect(select.isOpen).toBe(false);
             });
+
+            it('should not open dropdown if [openOnEnter]="false"', fakeAsync(() => {
+                select.openOnEnter = false;
+                triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Enter);
+                expect(select.isOpen).toBe(false);
+            }));
         });
     });
 

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -730,11 +730,12 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             } else if (this.showAddTag) {
                 this.selectTag();
             }
-        } else if (this.openOnEnter === false) {
-            return;
-        } else {
+        } else if (this.openOnEnter === true) {
             this.open();
+        } else {
+            return;
         }
+
         $event.preventDefault();
         $event.stopPropagation();
     }

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -730,7 +730,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             } else if (this.showAddTag) {
                 this.selectTag();
             }
-        } else if (this.openOnEnter === true) {
+        } else if (this.openOnEnter) {
             this.open();
         } else {
             return;

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -92,6 +92,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() closeOnSelect = true;
     @Input() hideSelected = false;
     @Input() selectOnTab = false;
+    @Input() openOnEnter: boolean;
     @Input() maxSelectedItems: number;
     @Input() groupBy: string | Function;
     @Input() groupValue: Function;
@@ -729,6 +730,8 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             } else if (this.showAddTag) {
                 this.selectTag();
             }
+        } else if (this.openOnEnter === false) {
+            return;
         } else {
             this.open();
         }
@@ -801,5 +804,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         this.addTagText = this.addTagText || config.addTagText;
         this.loadingText = this.loadingText || config.loadingText;
         this.clearAllText = this.clearAllText || config.clearAllText;
+        this.openOnEnter = this.openOnEnter !== undefined ? this.openOnEnter : config.openOnEnter;
     }
 }

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -804,6 +804,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         this.addTagText = this.addTagText || config.addTagText;
         this.loadingText = this.loadingText || config.loadingText;
         this.clearAllText = this.clearAllText || config.clearAllText;
-        this.openOnEnter = this.openOnEnter !== undefined ? this.openOnEnter : config.openOnEnter;
+        this.openOnEnter = isDefined(this.openOnEnter) ? this.openOnEnter : config.openOnEnter;
     }
 }

--- a/src/ng-select/ng-select.module.ts
+++ b/src/ng-select/ng-select.module.ts
@@ -63,7 +63,8 @@ import { DefaultSelectionModelFactory } from './selection-model';
                 addTagText: 'Add item',
                 loadingText: 'Loading...',
                 clearAllText: 'Clear all',
-                disableVirtualScroll: false
+                disableVirtualScroll: false,
+                openOnEnter: true
             }
         }
     ]

--- a/src/ng-select/ng-select.types.ts
+++ b/src/ng-select/ng-select.types.ts
@@ -22,6 +22,7 @@ export enum KeyCode {
 }
 
 export interface NgSelectConfig {
+    openOnEnter?: boolean;
     placeholder?: string;
     notFoundText?: string;
     typeToSearchText?: string;


### PR DESCRIPTION
Resolves #877 - Adds an `openOnEnter` parameter that defaults to true, and can be set in the global config. This keeps the current functionality while providing a route to enable the more accessible behavior globally.