### PR TITLE
fix: repository links, silence angular 7 install warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ng-select/ng-select.git"
-  },
+  "repository": "ng-select/ng-select",
   "engines": {
     "node": ">= 6.9.0",
     "npm": ">= 3.0.0"

--- a/src/package.json
+++ b/src/package.json
@@ -5,7 +5,7 @@
   "description": "Angular ng-select - All in One UI Select, Multiselect and Autocomplete",
   "author": "@ng-select/ng-select",
   "license": "MIT",
-  "repository": "git@github.com:ng-select/ng-select.git",
+  "repository": "ng-select/ng-select",
   "engines": {
     "node": ">= 6.9.0",
     "npm": ">= 3.0.0"
@@ -21,9 +21,9 @@
     "angular4"
   ],
   "peerDependencies": {
-    "@angular/common": ">=6.0.0 <7.0.0",
-    "@angular/core": ">=6.0.0 <7.0.0",
-    "@angular/forms": ">=6.0.0 <7.0.0"
+    "@angular/common": ">=6.0.0 <8.0.0",
+    "@angular/core": ">=6.0.0 <8.0.0",
+    "@angular/forms": ">=6.0.0 <8.0.0"
   },
   "ngPackage": {
     "lib": {


### PR DESCRIPTION
closes #883

https://www.npmjs.com/package/@ng-select/ng-select should have a link back to github if its working correctly, so I've updated it with a nice short github link that should work.


<img width="401" alt="no link to github" src="https://user-images.githubusercontent.com/1400464/47229578-e10e0d00-d37c-11e8-88e0-bce85648e48e.png">
no link back to github ^