### PR TITLE
feat: enable overwriting of clear all icon with css

### DIFF
--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -274,7 +274,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         }
         $event.stopPropagation();
 
-        if (target.className === 'ng-clear') {
+        if (target.className === 'ng-clear-wrapper') {
             this.handleClearClick();
             return;
         }


### PR DESCRIPTION
Fixing issue #835 

This css should do the trick for overwriting the icon:

`.ng-select.custom .ng-clear-wrapper .ng-clear  {
    display:none;
}

.ng-select.custom .ng-clear-wrapper:after  {
    color: #337ab7;
    font-size: 12px;
    font-family: 'Glyphicons Halflings';
    content: "\e014";
}`