### PR TITLE
Feature/custom clear all icon

### DIFF
--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -2769,7 +2769,7 @@ describe('NgSelectComponent', function () {
                 tickAndDetectChanges(fixture);
                 triggerMousedown = () => {
                     const control = fixture.debugElement.query(By.css('.ng-select-container'));
-                    control.triggerEventHandler('mousedown', createEvent({ className: 'ng-clear' }));
+                    control.triggerEventHandler('mousedown', createEvent({ className: 'ng-clear-wrapper' }));
                 };
             }));
 

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -274,7 +274,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         }
         $event.stopPropagation();
 
-        if (target.className === 'ng-clear') {
+        if (target.className === 'ng-clear-wrapper') {
             this.handleClearClick();
             return;
         }


### PR DESCRIPTION
Fixing issue #835

This css should do the trick for overwriting the icon:

`.ng-select.custom .ng-clear-wrapper .ng-clear {
display:none;
}

.ng-select.custom .ng-clear-wrapper:after {
color: #337ab7;
font-size: 12px;
font-family: 'Glyphicons Halflings';
content: "\e014";
}`