### PR TITLE
Feature/global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,23 @@ To allow customization and theming, `ng-select` bundle includes only generic sty
 
 ### Step 4 (Optional): Configuration 
 
-You can also set global configuration and localization messages by injecting NgSelectConfig service,
-typically in your root component, and customize the values of its properties in order to provide default values.
-
-```js
-  constructor(private config: NgSelectConfig) {
-      this.config.notFoundText = 'Custom not found';
-  }
+You can also set global configuration and localization messages by by providing custom NgSelectConfig:
+ ```ts
+{ 
+    provide: NgSelectConfig,
+    useValue: new NgSelectConfig({
+       notFoundText: 'Custom not found'
+    })
+ }
 ```
+ or using `forRoot` syntax:
+
+```ts
+NgSelectModule.forRoot({
+  notFoundText: 'Custom not found'
+})
+```
+This configuration is shared by all imported NgSelectModule by default and could be overridden at any point of the application tree.
 ### SystemJS
 If you are using SystemJS, you should also adjust your configuration to point to the UMD bundle.
 

--- a/integration/src/app/app.component.ts
+++ b/integration/src/app/app.component.ts
@@ -14,8 +14,4 @@ export class AppComponent {
     {id: 2, name: 'Kaunas'},
     {id: 3, name: 'Pabradė'}
   ];
-
-  constructor(config: NgSelectConfig) {
-      config.notFoundText = 'Custom not found';
-  }
 }

--- a/integration/src/app/app.module.ts
+++ b/integration/src/app/app.module.ts
@@ -14,7 +14,9 @@ import { NgSelectModule } from '@ng-select/ng-select';
     CommonModule,
     FormsModule,
     BrowserModule.withServerTransition({ appId: 'ng-select' }),
-    NgSelectModule,
+    NgSelectModule.forRoot({
+        notFoundText: 'Custom not found'
+    }),
   ],
   bootstrap: [AppComponent]
 })

--- a/integration/src/app/app.module.ts
+++ b/integration/src/app/app.module.ts
@@ -14,7 +14,7 @@ import { NgSelectModule } from '@ng-select/ng-select';
     CommonModule,
     FormsModule,
     BrowserModule.withServerTransition({ appId: 'ng-select' }),
-    NgSelectModule
+    NgSelectModule,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/ng-select/config.service.ts
+++ b/src/ng-select/config.service.ts
@@ -1,7 +1,15 @@
-import { Injectable } from '@angular/core';
+export interface NgSelectConfigPayload {
+    placeholder?: string;
+    notFoundText?: string;
+    typeToSearchText?: string;
+    addTagText?: string;
+    loadingText?: string;
+    clearAllText?: string;
+    disableVirtualScroll?: boolean;
+    openOnEnter?: boolean;
+}
 
-@Injectable({providedIn: 'root'})
-export class NgSelectConfig {
+export class NgSelectConfig implements NgSelectConfigPayload {
     placeholder: string;
     notFoundText = 'No items found';
     typeToSearchText = 'Type to search';
@@ -10,4 +18,9 @@ export class NgSelectConfig {
     clearAllText = 'Clear all';
     disableVirtualScroll = true;
     openOnEnter = true;
+    constructor(payload?: NgSelectConfigPayload) {
+        Object.assign(this, payload);
+    }
 }
+
+export const defaultConfig = new NgSelectConfig();

--- a/src/ng-select/config.service.ts
+++ b/src/ng-select/config.service.ts
@@ -1,3 +1,8 @@
+import {InjectionToken} from '@angular/core';
+
+export const NG_SELECT_CONFIG_PAYLOAD = new InjectionToken<NgSelectConfigPayload>('NG_SELECT_CONFIG_PAYLOAD');
+export const NG_SELECT_CONFIG = new InjectionToken<NgSelectConfig>('NG_SELECT_CONFIG');
+
 export interface NgSelectConfigPayload {
     placeholder?: string;
     notFoundText?: string;
@@ -23,4 +28,6 @@ export class NgSelectConfig implements NgSelectConfigPayload {
     }
 }
 
-export const defaultConfig = new NgSelectConfig();
+export function configFactory(providedConfig: NgSelectConfig, providedPayload: NgSelectConfigPayload) {
+    return providedConfig || new NgSelectConfig(providedPayload);
+}

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -22,7 +22,6 @@ import {
     QueryList,
     InjectionToken,
     Attribute,
-    Optional
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { takeUntil, startWith, tap, debounceTime, map, filter } from 'rxjs/operators';
@@ -49,7 +48,7 @@ import { newId } from './id';
 import { NgDropdownPanelComponent } from './ng-dropdown-panel.component';
 import { NgOptionComponent } from './ng-option.component';
 import { SelectionModelFactory } from './selection-model';
-import {defaultConfig, NgSelectConfig} from './config.service';
+import {NG_SELECT_CONFIG, NgSelectConfig} from './config.service';
 
 export const SELECTION_MODEL_FACTORY = new InjectionToken<SelectionModelFactory>('ng-select-selection-model');
 export type DropdownPosition = 'bottom' | 'top' | 'auto';
@@ -187,13 +186,13 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         @Attribute('class') public classes: string,
         @Attribute('tabindex') public tabIndex: string,
         @Attribute('autofocus') private autoFocus: any,
-        @Optional() config: NgSelectConfig,
+        @Inject(NG_SELECT_CONFIG) config: NgSelectConfig,
         @Inject(SELECTION_MODEL_FACTORY) newSelectionModel: SelectionModelFactory,
         _elementRef: ElementRef,
         private _cd: ChangeDetectorRef,
         private _console: ConsoleService
     ) {
-        this._mergeGlobalConfig(config || defaultConfig);
+        this._mergeGlobalConfig(config);
         this.itemsList = new ItemsList(this, newSelectionModel());
         this.element = _elementRef.nativeElement;
     }

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -21,7 +21,8 @@ import {
     ContentChildren,
     QueryList,
     InjectionToken,
-    Attribute
+    Attribute,
+    Optional
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { takeUntil, startWith, tap, debounceTime, map, filter } from 'rxjs/operators';
@@ -48,7 +49,7 @@ import { newId } from './id';
 import { NgDropdownPanelComponent } from './ng-dropdown-panel.component';
 import { NgOptionComponent } from './ng-option.component';
 import { SelectionModelFactory } from './selection-model';
-import { NgSelectConfig } from './config.service';
+import {defaultConfig, NgSelectConfig} from './config.service';
 
 export const SELECTION_MODEL_FACTORY = new InjectionToken<SelectionModelFactory>('ng-select-selection-model');
 export type DropdownPosition = 'bottom' | 'top' | 'auto';
@@ -186,13 +187,13 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         @Attribute('class') public classes: string,
         @Attribute('tabindex') public tabIndex: string,
         @Attribute('autofocus') private autoFocus: any,
-        config: NgSelectConfig,
+        @Optional() config: NgSelectConfig,
         @Inject(SELECTION_MODEL_FACTORY) newSelectionModel: SelectionModelFactory,
         _elementRef: ElementRef,
         private _cd: ChangeDetectorRef,
         private _console: ConsoleService
     ) {
-        this._mergeGlobalConfig(config);
+        this._mergeGlobalConfig(config || defaultConfig);
         this.itemsList = new ItemsList(this, newSelectionModel());
         this.element = _elementRef.nativeElement;
     }

--- a/src/ng-select/ng-select.module.ts
+++ b/src/ng-select/ng-select.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import {ModuleWithProviders, NgModule} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgSelectComponent, SELECTION_MODEL_FACTORY } from './ng-select.component';
 import {
@@ -17,6 +17,7 @@ import { NgOptionComponent } from './ng-option.component';
 import { NgOptionHighlightDirective } from './ng-option-highlight.directive';
 import { NgDropdownPanelComponent } from './ng-dropdown-panel.component';
 import { DefaultSelectionModelFactory } from './selection-model';
+import {NgSelectConfig, NgSelectConfigPayload} from './config.service';
 
 @NgModule({
     declarations: [
@@ -54,7 +55,16 @@ import { DefaultSelectionModelFactory } from './selection-model';
         NgTagTemplateDirective
     ],
     providers: [
-        { provide: SELECTION_MODEL_FACTORY, useValue: DefaultSelectionModelFactory }
+        { provide: SELECTION_MODEL_FACTORY, useValue: DefaultSelectionModelFactory },
     ]
 })
-export class NgSelectModule { }
+export class NgSelectModule {
+    static forRoot(config?: NgSelectConfigPayload): ModuleWithProviders {
+        return {
+            ngModule: NgSelectModule,
+            providers: [
+                { provide: NgSelectConfig, useValue: new NgSelectConfig(config) },
+            ]
+        }
+    }
+}

--- a/src/ng-select/ng-select.module.ts
+++ b/src/ng-select/ng-select.module.ts
@@ -1,4 +1,4 @@
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import { ModuleWithProviders, NgModule, Optional, Provider } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgSelectComponent, SELECTION_MODEL_FACTORY } from './ng-select.component';
 import {
@@ -17,7 +17,24 @@ import { NgOptionComponent } from './ng-option.component';
 import { NgOptionHighlightDirective } from './ng-option-highlight.directive';
 import { NgDropdownPanelComponent } from './ng-dropdown-panel.component';
 import { DefaultSelectionModelFactory } from './selection-model';
-import {NgSelectConfig, NgSelectConfigPayload} from './config.service';
+import {
+    configFactory,
+    NG_SELECT_CONFIG,
+    NG_SELECT_CONFIG_PAYLOAD,
+    NgSelectConfig,
+    NgSelectConfigPayload
+} from './config.service';
+
+export const providers: Provider[] = [
+    { provide: SELECTION_MODEL_FACTORY, useValue: DefaultSelectionModelFactory },
+    {
+        provide: NG_SELECT_CONFIG,
+        useFactory: configFactory,
+        deps: [
+            [new Optional(), NgSelectConfig],
+            [new Optional(), NG_SELECT_CONFIG_PAYLOAD]]
+    },
+];
 
 @NgModule({
     declarations: [
@@ -54,16 +71,16 @@ import {NgSelectConfig, NgSelectConfigPayload} from './config.service';
         NgLoadingTextTemplateDirective,
         NgTagTemplateDirective
     ],
-    providers: [
-        { provide: SELECTION_MODEL_FACTORY, useValue: DefaultSelectionModelFactory },
-    ]
+    providers
+
 })
 export class NgSelectModule {
     static forRoot(config?: NgSelectConfigPayload): ModuleWithProviders {
         return {
             ngModule: NgSelectModule,
             providers: [
-                { provide: NgSelectConfig, useValue: new NgSelectConfig(config) },
+                { provide: NG_SELECT_CONFIG_PAYLOAD, useValue: config },
+                ...providers
             ]
         }
     }


### PR DESCRIPTION
This pr fixes issue #926

1. The configuration could be partly provided via `forRoot` or `providers` syntax.
2. Configuration is shared by all the modules and can be rewritten at any point.
