### PR TITLE
[fix] - $event.path does not work in Safari and Firefox. Replace with $event.composedPath().

### DIFF
--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -210,7 +210,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
             return;
         }
 
-        if ($event.target && $event.target.shadowRoot && $event.path && $event.path[0] && this._select.contains($event.path[0])) {
+        if ($event.target && $event.target.shadowRoot && $event.composedPath() && $event.composedPath()[0] && this._select.contains($event.composedPath()[0])) {
             return;
         }
 

--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -210,7 +210,8 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
             return;
         }
 
-        if ($event.target && $event.target.shadowRoot && $event.composedPath() && $event.composedPath()[0] && this._select.contains($event.composedPath()[0])) {
+        if ($event.target && $event.target.shadowRoot && $event.composedPath() && $event.composedPath()[0]
+            && this._select.contains($event.composedPath()[0])) {
             return;
         }
 

--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -210,12 +210,9 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
             return;
         }
 
-        if ($event.target && $event.target.shadowRoot && $event.composedPath() && $event.composedPath()[0]
-            && this._select.contains($event.composedPath()[0])) {
-            return;
-        }
+        const path = $event.path || ($event.composedPath && $event.composedPath());
 
-        if ($event.target && $event.target.shadowRoot && $event.path && $event.path[0] && this._select.contains($event.path[0])) {
+        if ($event.target && $event.target.shadowRoot && path && path[0] && this._select.contains(path[0])) {
             return;
         }
 

--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -215,6 +215,10 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
             return;
         }
 
+        if ($event.target && $event.target.shadowRoot && $event.path && $event.path[0] && this._select.contains($event.path[0])) {
+            return;
+        }
+
         this.outsideClick.emit();
     }
 


### PR DESCRIPTION
$event.path does not work in Safari and Firefox. Changing that with $event.composedPath() will give it cross-browser support. 

https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath