### PR TITLE
[Bug] Dropdown position not always correctly updated with virtual scrolling 

### DIFF
--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -270,6 +270,8 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
 
                 if (this._startupLoop === true) {
                     loop(resolve)
+                } else {
+                    resolve();
                 }
 
             } else if (this._startupLoop === true) {


### PR DESCRIPTION
### Description

The dropdown of the multi-select is not always correctly positioned when the virtual scrolling is enabled. This happens because there is a case in which the promise after updating the list items is not resolved. Thus the list position is not updated.

![ng-select-dropdown-position](https://user-images.githubusercontent.com/7457313/51256000-a9772700-19a4-11e9-8f52-afa8db081aea.gif)

https://stackblitz.com/edit/angular-hxjvkx