### PR TITLE
Accessibility Support enhancements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ map: {
 | bindValue  | `string` | `-` | no | Object property to use for selected model. By default binds to whole object. |
 | bindLabel  | `string` | `label` | no | Object property to use for label. Default `label`  |
 | [closeOnSelect] | `boolean` |  true | no | Whether to close the menu when a value is selected |
-| clearAllText | `string` | `Clear all` | no | Set custom text for clear all icon title |
+| clearAllText | `string` | `Clear all` | no | Set custom text for clear all icon button title |
+| toggleDropdownText | `string` | `Toggle dropdown` | no | Set custom text for toggle dropdown icon button title |
 | [clearable] | `boolean` | `true` | no | Allow to clear selected value. Default `true`|
 | [clearOnBackspace] | `boolean` | `true` | no | Clear selected values one by one when clicking backspace. Default `true`|
 | [compareWith] | `(a: any, b: any) => boolean` | `(a, b) => a === b` | no | A function to compare the option values with the selected values. The first argument is a value from an option. The second is a value from the selection(model). A boolean should be returned. |

--- a/demo/app/app.component.html
+++ b/demo/app/app.component.html
@@ -7,7 +7,7 @@
         <main class="col-12 col-md-9 col-xl-8 py-md-4 pl-md-4 bd-content">
             <div class="d-flex">
                 <div style="flex:1;">
-                    <h2 class="bd-title">{{title}}</h2>
+                    <h1 class="bd-title">{{title}}</h1>
                 </div>
                 <div style="align-self:center;">
                     <a href="{{exampleSourceUrl}}" target="_blank"><i class="fa fa-code"></i> Example source code</a>

--- a/demo/app/app.module.ts
+++ b/demo/app/app.module.ts
@@ -39,10 +39,10 @@ export const appRoutes: Routes = [
     { path: 'tags', component: SelectTagsComponent, data: { title: 'Tags', fileName: 'tags.component.ts' } },
     { path: 'templates', component: SelectWithTemplatesComponent, data: { title: 'Templates', fileName: 'custom-templates.component.ts' } },
     { path: 'multiselect', component: SelectMultiComponent, data: { title: 'Multiselect', fileName: 'multi.component.ts' } },
-    { 
+    {
         path: 'multiselect-checkbox',
         component: SelectMultiCheckboxComponent,
-        data: { title: 'Multiselect checkbox', fileName: 'multi-checkbox.component.ts' } 
+        data: { title: 'Multiselect checkbox', fileName: 'multi-checkbox.component.ts' }
     },
     { path: 'events', component: SelectEventsComponent, data: { title: 'Output events', fileName: 'events.component.ts' } },
     // tslint:disable-next-line:max-line-length
@@ -51,7 +51,7 @@ export const appRoutes: Routes = [
     { path: 'dropdown-position', component: DropdownPositionsComponent, data: { title: 'Dropdown position', fileName: 'dropdown-positions.component.ts' } },
     // tslint:disable-next-line:max-line-length
     { path: 'append-to-element', component: AppendToComponent, data: { title: 'Append to element', fileName: 'append-to.component.ts' } },
-    { path: 'grouping', component: SelectGroupsComponent, data: { title: 'Grouping', fileName: 'groups.component.ts' } },
+    { path: 'grouping', component: SelectGroupsComponent, data: { title: 'Grouping', fileName: 'groups.component.ts' } }
 ];
 
 @NgModule({

--- a/demo/app/examples/data-source.component.ts
+++ b/demo/app/examples/data-source.component.ts
@@ -110,3 +110,4 @@ export class DataSourceComponent {
 }
 
 
+

--- a/demo/app/layout/header.component.ts
+++ b/demo/app/layout/header.component.ts
@@ -9,7 +9,7 @@ type langDir = 'ltr' | 'rtl';
     template: `
         <nav class="navbar navbar-expand navbar-dark flex-column flex-md-row bd-navbar bg-dark">
             <a class="navbar-brand" href="#">
-                <img src="https://angular.io/assets/images/logos/angular/angular.svg" width="32px" height="32px"/>
+                <img src="https://angular.io/assets/images/logos/angular/angular.svg" width="32px" height="32px" alt="Angular Logo"/>
                 @ng-select/ng-select@{{version}}
             </a>
             <button class="navbar-toggler"

--- a/demo/app/layout/sidenav-component.ts
+++ b/demo/app/layout/sidenav-component.ts
@@ -4,11 +4,13 @@ import { appRoutes } from '../app.module';
 @Component({
     selector: 'layout-sidenav',
     template: `
-        <ul class="nav nav-pills flex-column">
-            <li class="nav-item" routerLinkActive="active" *ngFor="let route of routes">
-                <a class="nav-link" routerLink="{{route.url}}" routerLinkActive="active">{{route.title}}</a>
-            </li>
-        </ul>
+        <nav>
+            <ul class="nav nav-pills flex-column">
+                <li class="nav-item" routerLinkActive="active" *ngFor="let route of routes">
+                    <a class="nav-link" routerLink="{{route.url}}" routerLinkActive="active">{{route.title}}</a>
+                </li>
+            </ul>
+        </nav>
     `
 })
 export class LayoutSidenavComponent {

--- a/demo/index.ejs
+++ b/demo/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <title>ng-select component demo</title>

--- a/now.json
+++ b/now.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "alias": "brunano21-ng-select",
+  "builds": [{ "src": "./package.json", "use": "@now/static-build",  "config": { "distDir": "dist_" }}]
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "coveralls": "cat ./coverage/lcov/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "integration": "./integration_test.sh",
     "lint": "tslint --type-check --project ./src/tsconfig.json",
-    "release": "sh ./release.sh"
+    "release": "sh ./release.sh",
+    "now-build": "rimraf dist_ && mkdir -p dist_/ng-select && yarn run build:demo && cp -r dist/** dist_/ && mv dist_/js dist_/ng-select && yarn run build && cp -r dist/** dist_/ng-select"
   },
   "devDependencies": {
     "@angular/animations": "^6.1.2",

--- a/src/ng-select/config.service.ts
+++ b/src/ng-select/config.service.ts
@@ -8,6 +8,7 @@ export class NgSelectConfig {
     addTagText = 'Add item';
     loadingText = 'Loading...';
     clearAllText = 'Clear all';
+    toggleDropdownText = 'Toggle dropdown';
     disableVirtualScroll = true;
     openOnEnter = true;
 }

--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -41,7 +41,7 @@ const BOTTOM_CSS_CLASS = 'ng-select-bottom';
         </div>
         <div #scroll class="ng-dropdown-panel-items scroll-host">
             <div #padding [class.total-padding]="virtualScroll"></div>
-            <div #content [class.scrollable-content]="virtualScroll && items.length > 0">
+            <div #content [class.scrollable-content]="virtualScroll && items.length > 0" role="listbox">
                 <ng-content></ng-content>
             </div>
         </div>

--- a/src/ng-select/ng-select.component.html
+++ b/src/ng-select/ng-select.component.html
@@ -1,11 +1,28 @@
-<div (mousedown)="handleMousedown($event)" [class.ng-has-value]="hasValue" class="ng-select-container">
+<div [class.ng-has-value]="hasValue"
+     class="ng-select-container"
+     [attr.role]="multiple ? 'listbox' : null"
+     [attr.aria-orientation]="multiple ? 'horizontal' : null"
+     [attr.aria-haspopup]="multiple ? 'listbox' : null"
+     [attr.aria-multiselectable]="multiple ? 'true' : null"
+     [attr.aria-labelledby]="multiple ? labelForId : null"
+     [tabIndex]="(multiple && selectedItems.length > 0 && !focusedTag) ? 0 : -1"
+     (focus)="onWidgetFocus()"
+     (mousedown)="handleMousedown($event)">
     <div class="ng-value-container">
-        <div class="ng-placeholder">{{placeholder}}</div>
+        <div class="ng-placeholder" aria-hidden="true">{{placeholder}}</div>
 
-        <ng-container *ngIf="!multiLabelTemplate && selectedItems.length > 0">
-            <div [class.ng-value-disabled]="item.disabled" class="ng-value" *ngFor="let item of selectedItems">
+        <ng-container *ngIf="((multiple && !multiLabelTemplate) || !searchable) && selectedItems.length > 0">
+            <div #tag *ngFor="let item of selectedItems"
+                 [class.ng-value-disabled]="item.disabled"
+                 [attr.aria-disabled]="item.disabled"
+                 class="ng-value"
+                 tabindex="-1"
+                 role="option"
+                 aria-selected="true"
+                 (blur)="onTagBlur($event)"
+                 [id]="item.htmlId">
                 <ng-template #defaultLabelTemplate>
-                    <span class="ng-value-icon left" (click)="unselect(item);" aria-hidden="true">×</span>
+                    <span class="ng-value-icon ng-icon-button left" (click)="unselect(item);" aria-hidden="true">×</span>
                     <span class="ng-value-label">{{item.label}}</span>
                 </ng-template>
 
@@ -17,14 +34,15 @@
         </ng-container>
 
         <ng-template *ngIf="multiLabelTemplate && selectedValues.length > 0"
-                [ngTemplateOutlet]="multiLabelTemplate"
-                [ngTemplateOutletContext]="{ items: selectedValues, clear: clearItem }">
+                     [ngTemplateOutlet]="multiLabelTemplate"
+                     [ngTemplateOutletContext]="{ items: selectedValues, clear: clearItem }">
         </ng-template>
 
         <div class="ng-input">
             <input #filterInput
                    type="text"
                    [attr.autocomplete]="labelForId ? 'off' : dropdownId"
+                   [attr.placeholder]="(!multiple || !searchable) ? placeholder : (hasValue ? '' : placeholder)"
                    [attr.id]="labelForId"
                    [attr.tabindex]="tabIndex"
                    [readOnly]="!searchable"
@@ -35,6 +53,7 @@
                    (blur)="onInputBlur($event)"
                    (change)="$event.stopPropagation()"
                    role="combobox"
+                   aria-autocomplete="list"
                    [attr.aria-expanded]="isOpen"
                    [attr.aria-owns]="isOpen ? dropdownId : null"
                    [attr.aria-activedescendant]="isOpen ? itemsList?.markedItem?.htmlId : null">
@@ -43,12 +62,22 @@
 
     <div class="ng-spinner-loader" *ngIf="loading"></div>
 
-    <span *ngIf="showClear()" class="ng-clear-wrapper" title="{{clearAllText}}">
-        <span class="ng-clear" aria-hidden="true">×</span>
+    <span *ngIf="showClear()" class="ng-clear-wrapper">
+        <button class="ng-icon-button ng-clear-button"
+                title="{{clearAllText}}"
+                (keydown.enter)="$event.preventDefault(); $event.stopPropagation(); handleClearClick();"
+                (keydown.space)="$event.preventDefault(); $event.stopPropagation(); handleClearClick();">
+            <span class="ng-clear" aria-hidden="true">×</span>
+        </button>
     </span>
 
     <span class="ng-arrow-wrapper">
-        <span class="ng-arrow"></span>
+        <button class="ng-icon-button ng-arrow-button"
+                title="{{toggleDropdownText}}"
+                (keydown.enter)="$event.preventDefault(); $event.stopPropagation(); handleArrowClick();"
+                (keydown.space)="$event.preventDefault(); $event.stopPropagation(); handleArrowClick();">
+            <span class="ng-arrow" aria-hidden="true"></span>
+        </button>
     </span>
 </div>
 
@@ -80,6 +109,7 @@
                 [class.ng-option]="!item.children"
                 [class.ng-option-child]="!!item.parent"
                 [class.ng-option-marked]="item === itemsList.markedItem"
+                [attr.aria-disabled]="item.disabled"
                 [attr.aria-selected]="item.selected"
                 [attr.id]="item?.htmlId">
 

--- a/src/ng-select/ng-select.component.scss
+++ b/src/ng-select/ng-select.component.scss
@@ -23,8 +23,24 @@
         display: none;
     }
     &.ng-select-searchable {
-        .ng-select-container .ng-value-container .ng-input {
-            opacity: 1;
+        .ng-select-container {
+            .ng-value-container {
+                .ng-placeholder {
+                    display: none;
+                }
+                .ng-input {
+                    opacity: 1;
+                }
+            }
+        }
+    }
+    &:not(.ng-select-searchable) {
+        .ng-has-value {
+            .ng-input {
+                input {
+                    opacity: 0;
+                }
+            }
         }
     }
     &.ng-select-opened .ng-select-container {
@@ -61,7 +77,6 @@
             display: flex;
             flex: 1;
             .ng-input {
-                opacity: 0;
                 > input {
                     box-sizing: content-box;
                     background: none transparent;
@@ -140,15 +155,23 @@
             }
         }
     }
+    .ng-icon-button {
+        background: none;
+        color: inherit;
+        border: none;
+        font: inherit;
+        cursor: pointer;
+        padding: 0 5px;
+        margin: 0;
+    }
+
     .ng-clear-wrapper {
         cursor: pointer;
         position: relative;
-        width: 17px;
         user-select: none;
         .ng-clear {
             display: inline-block;
             font-size: 18px;
-            line-height: 1;
             pointer-events: none;
         }
     }

--- a/src/ng-select/ng-select.types.ts
+++ b/src/ng-select/ng-select.types.ts
@@ -15,8 +15,13 @@ export enum KeyCode {
     Tab = 9,
     Enter = 13,
     Esc = 27,
+    Home = 36,
+    End = 35,
     Space = 32,
     ArrowUp = 38,
     ArrowDown = 40,
-    Backspace = 8
+    ArrowLeft = 37,
+    ArrowRight = 39,
+    Backspace = 8,
+    Delete = 46
 }

--- a/src/themes/default.theme.scss
+++ b/src/themes/default.theme.scss
@@ -61,9 +61,6 @@ $color-selected: #f5faff;
                 padding-right: 10px;
                 padding-left: 0
             }
-            .ng-placeholder {
-                color: #aaa;
-            }
         }
     }
     &.ng-select-single {
@@ -78,6 +75,9 @@ $color-selected: #f5faff;
                     @include rtl {
                         padding-right: 10px;
                         padding-left: 50px;
+                    }
+                    input::placeholder {
+                        color: #aaa;
                     }
                 }
             }
@@ -123,6 +123,10 @@ $color-selected: #f5faff;
                             }
                         }
                     }
+                    &:focus {
+                        border-color: #007eff;
+                        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 0 3px rgba(0, 126, 255, 0.1);
+                    }
                     .ng-value-label {
                         display: inline-block;
                         padding: 0 5px 0 5px;
@@ -153,15 +157,6 @@ $color-selected: #f5faff;
                     padding: 0 0 3px 3px;
                     @include rtl {
                         padding: 0 3px 3px 0;
-                    }
-                }
-                .ng-placeholder {
-                    top: 5px;
-                    padding-bottom: 5px;
-                    padding-left: 3px;
-                    @include rtl {
-                        padding-right: 3px;
-                        padding-left: 0;
                     }
                 }
             }

--- a/src/themes/material.theme.scss
+++ b/src/themes/material.theme.scss
@@ -41,6 +41,18 @@ $highlight-color: #3f51b5 !default;
             }
         }
     }
+    &.ng-select-searchable {
+        .ng-select-container {
+            .ng-value-container {
+                .ng-placeholder {
+                    display: initial;
+                }
+                input::placeholder {
+                    opacity: 0;
+                }
+            }
+        }
+    }
     .ng-has-value,
     &.ng-select-filtered .ng-select-container {
         .ng-placeholder {


### PR DESCRIPTION
Hi,

With the following PR, I'd like to add a few enhancements for a better `ng-select` accessibility support.
In particular, what I did so far was:
- [x] fixed a few minor accessibility issues for the demo app.
- [x] added an Accessibility component into the demo app for test purposes.
- [x] convert "clear all" and "dropdown" icon `<span>`s into `<button>`. 
- [x] when in _single select_ mode and an item has been selected, the inner `<input>`'s `<value>` attribute is set to the selected item label. This allows a screen reader to read properly the widget's value.
- [x] when in _multi select_ mode, selected items are navigable via keyboard, If you tab into the widget and the widget holds some selected values, the focus will be sent to a `role=listbox` tag list, specifically to the first selected item tag. From now the user can: 
   - navigate to the next selected item by pressing `ArrowRight` key. 
   - navigate to the previous selected item by pressing `ArrorLeft` key.
   - navigate to the last selected item by pressing `End` key.
   - navigate to the first selected item by pressing `Home` key.
   - delete the focused selected item by pressing `Delete` key.
   If the user tabs again, the focus will be sent to the `input` (if not `read-only`).
- [x] fix style for the default theme.
- [x] fix style for the material theme.
- [x] fix all tests (**I would need some help from maintainers for this, please**).
- [ ] clean up (i.e. remove the Accessibility component from the demo app, remove `now.js` file needed for deployment, stripe out _now_ deployment script from `package.json`).
- [x] update the README.
- [x] squash commits.

Please note, that I'm using Zeit's Now for deployment. You can see the current code into master at [https://brunano21-ng-select.now.sh](https://brunano21-ng-select.now.sh)