### PR TITLE
fix: do not append dropdown, nor update its position when it is destroyed

### DIFF
--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -129,6 +129,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
         this._disposeScrollListener();
         this._destroy$.next();
         this._destroy$.complete();
+        this._destroy$.unsubscribe();
         if (this.appendTo) {
             this._renderer.removeChild(this._dropdown.parentNode, this._dropdown);
         }
@@ -136,6 +137,9 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
 
     ngAfterContentInit() {
         this._whenContentReady().then(() => {
+            if (this._destroy$.closed) {
+                return;
+            }
             if (this.appendTo) {
                 this._appendDropdown();
                 this._handleDocumentResize();

--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -1113,6 +1113,28 @@ describe('NgSelectComponent', function () {
 
             expect(fixture.componentInstance.select.isOpen).toBeTruthy();
         }));
+
+        it('should not append dropdown, nor update its position when it is destroyed', async(() => {
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `
+                <ng-select [items]="cities"
+                        appendTo="body"
+                        [(ngModel)]="city">
+                </ng-select>`);
+
+            fixture.componentInstance.select.open();
+            fixture.detectChanges();
+            fixture.componentInstance.select.close();
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => {
+                const selectClasses = (<HTMLElement>fixture.nativeElement).querySelector('.ng-select').classList;
+                expect(selectClasses.contains('ng-select-bottom')).toBeFalsy();
+                const dropdown = <HTMLElement>document.querySelector('.ng-dropdown-panel');
+                expect(dropdown).toBeNull();
+            });
+        }));
     });
 
     describe('Keyboard events', () => {


### PR DESCRIPTION
Sometimes with more complex and heavy selects it's possible to glitch the dropdown panel by quickly clicking multiples times on "arrow" - the panel gets appended to body even though it is already closed/destroyed. So it hangs there forever on top of all elements/pages. (This happens only with `appendTo` property).

This happens because this line is not aware of `destroy$`: https://github.com/ng-select/ng-select/blob/97f4387e3e2680e1a4fbf33f76134c44dc31beb6/src/ng-select/ng-dropdown-panel.component.ts#L138