### PR TITLE
fix: Filter dropdown after selected item with virtualScroll

### DIFF
--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -492,7 +492,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
 
     filter(term: string) {
         this.filterValue = term;
-        this.open();
 
         if (this._isTypeahead) {
             this.typeahead.next(this.filterValue);
@@ -504,6 +503,8 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         }
 
         this.searchEvent.emit({ term, items: this.itemsList.filteredItems.map(x => x.value) });
+
+        this.open();
     }
 
     onInputFocus($event) {


### PR DESCRIPTION
The `this.open()` in the `filter()` will open the **NgDropdownComponent** and its `_handleItemsChange()` will refresh with the unfiltered data, only after this the **NgSelectComponent** will emit the filtered data to the **NgDropdownComponent**. 

I moved the `this.open()` to after emitting the data so **NgDropdownComponent** can render the filtered data.