### PR TITLE
Fix for #1122

### DIFF
--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -206,6 +206,10 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
 
             this._dropdown.style.opacity = '1';
         }, 0);
+        
+        if (_this.appendTo) {
+            _this._updateAppendedDropdownPosition();
+        }
     }
 
     private _handleOutsideClick($event: any) {

--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -207,8 +207,8 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
             this._dropdown.style.opacity = '1';
         }, 0);
         
-        if (_this.appendTo) {
-            _this._updateAppendedDropdownPosition();
+        if (this.appendTo) {
+            this._updateAppendedDropdownPosition();
         }
     }
 


### PR DESCRIPTION
Fixes #1122 

Calling _updateAppendedDropdownPosition outside of the setTimeout (as well as inside it still).

This stops the page's scroll height from changing for a split second.  It also needs to be inside the setTimeout so the proper top/bottom location is chosen.  Without it in both places its not always correct.