### PR TITLE
Add Block Strategy.

### DIFF
--- a/demo/app/examples/append-to.component.ts
+++ b/demo/app/examples/append-to.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+
 import { DataService } from '../shared/data.service';
 
 @Component({
@@ -30,6 +31,32 @@ import { DataService } from '../shared/data.service';
             </ng-select>
         </div>
         ---
+
+        <p>It can block scrolling when appended to an element using <b>blockStrategy</b>.</p>
+        ---html,true
+        <div class="big-overflow-box ">
+
+            <ng-select [items]="people | async"
+                bindLabel="company"
+                appendTo="body"
+                blockStrategy="block"
+                placeholder="Select item"
+                [(ngModel)]="selected">
+            </ng-select>
+
+            <ng-select [items]="people | async"
+                bindLabel="company"
+                appendTo="body"
+                blockStrategy="none"
+                placeholder="Select item"
+                [(ngModel)]="selected">
+            </ng-select>
+            
+            <div class="big-box">
+                &nbsp;
+            </div>
+        </div>
+        ---
     `,
     styles: [
         `
@@ -40,6 +67,18 @@ import { DataService } from '../shared/data.service';
                border: 1px solid #999;
                overflow: hidden;
            }
+
+           .big-overflow-box {
+                padding: 5px;
+                padding-right: 50px;
+                height: 200px;
+                border: 1px solid #999;
+                overflow: auto;
+           }
+
+           .big-box {
+                height: 400px;
+           }
         `
     ]
 })
@@ -49,6 +88,7 @@ export class AppendToComponent implements OnInit {
     people: any = [];
     selected: any;
     selected2: any;
+    selected3: any;
     constructor(private dataService: DataService) { }
 
     ngOnInit() { 

--- a/src/ng-select/items-list.spec.ts
+++ b/src/ng-select/items-list.spec.ts
@@ -1,7 +1,7 @@
-import { NgSelectComponent } from './ng-select.component';
-import { ItemsList } from './items-list';
-import { DefaultSelectionModel } from './selection-model';
 import { NgSelectConfig } from './config.service';
+import { ItemsList } from './items-list';
+import { NgSelectComponent } from './ng-select.component';
+import { DefaultSelectionModel } from './selection-model';
 
 describe('ItemsList', () => {
     describe('select', () => {
@@ -432,6 +432,6 @@ describe('ItemsList', () => {
     }
 
     function ngSelectFactory(): NgSelectComponent {
-        return new NgSelectComponent(null, null, null, new NgSelectConfig(), () => new DefaultSelectionModel(), {} as any, null, null);
+        return new NgSelectComponent(null, null, null, new NgSelectConfig(), () => new DefaultSelectionModel(), {} as any, null, null, null, null);
     }
 });

--- a/src/ng-select/items-list.spec.ts
+++ b/src/ng-select/items-list.spec.ts
@@ -432,6 +432,17 @@ describe('ItemsList', () => {
     }
 
     function ngSelectFactory(): NgSelectComponent {
-        return new NgSelectComponent(null, null, null, new NgSelectConfig(), () => new DefaultSelectionModel(), {} as any, null, null, null, null);
+        return new NgSelectComponent(
+            null,
+            null,
+            null,
+            new NgSelectConfig(),
+            () => new DefaultSelectionModel(),
+            {} as any,
+            null,
+            null,
+            null,
+            null
+        );
     }
 });

--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -1,32 +1,32 @@
-import {
-    Component,
-    OnDestroy,
-    Renderer2,
-    ElementRef,
-    Input,
-    EventEmitter,
-    Output,
-    ViewChild,
-    SimpleChanges,
-    NgZone,
-    TemplateRef,
-    ViewEncapsulation,
-    ChangeDetectionStrategy,
-    AfterContentInit,
-    OnInit,
-    OnChanges,
-    HostListener,
-    Optional,
-    Inject
-} from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-
-import { NgOption } from './ng-select.types';
-import { DropdownPosition } from './ng-select.component';
-import { WindowService } from './window.service';
-import { VirtualScrollService } from './virtual-scroll.service';
+import {
+    AfterContentInit,
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    EventEmitter,
+    HostListener,
+    Inject,
+    Input,
+    NgZone,
+    OnChanges,
+    OnDestroy,
+    OnInit,
+    Optional,
+    Output,
+    Renderer2,
+    SimpleChanges,
+    TemplateRef,
+    ViewChild,
+    ViewEncapsulation
+} from '@angular/core';
+import { fromEvent, merge, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { Subject, fromEvent, merge } from 'rxjs';
+
+import { BlockStrategy, DropdownPosition } from './ng-select.component';
+import { NgOption } from './ng-select.types';
+import { VirtualScrollService } from './virtual-scroll.service';
+import { WindowService } from './window.service';
 
 const TOP_CSS_CLASS = 'ng-select-top';
 const BOTTOM_CSS_CLASS = 'ng-select-bottom';
@@ -55,6 +55,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
     @Input() items: NgOption[] = [];
     @Input() markedItem: NgOption;
     @Input() position: DropdownPosition = 'auto';
+    @Input() blockStrategy: BlockStrategy = 'none';
     @Input() appendTo: string;
     @Input() bufferAmount = 4;
     @Input() virtualScroll = false;
@@ -73,6 +74,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
 
     private readonly _destroy$ = new Subject<void>();
     private readonly _dropdown: HTMLElement;
+    private _overlay: HTMLDivElement;
     private _select: HTMLElement;
     private _previousStart: number;
     private _previousEnd: number;
@@ -135,7 +137,12 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
         this._destroy$.complete();
         this._destroy$.unsubscribe();
         if (this.appendTo) {
-            this._renderer.removeChild(this._dropdown.parentNode, this._dropdown);
+
+            if (this.blockStrategy === 'block') {
+                this._renderer.removeChild(this._overlay.parentNode, this._overlay);
+            } else if (this.blockStrategy === 'none') {
+                this._renderer.removeChild(this._dropdown.parentNode, this._dropdown);
+            }
         }
     }
 
@@ -350,14 +357,34 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
 
     private _appendDropdown() {
         const parent = document.querySelector(this.appendTo);
+
         if (!parent) {
             throw new Error(`appendTo selector ${this.appendTo} did not found any parent element`)
         }
-        parent.appendChild(this._dropdown);
+
+        if (this.blockStrategy === 'block') {
+            this._overlay = this._renderer.createElement('div');
+            this._overlay.style.position = 'fixed';
+            this._overlay.style.top = '0';
+            this._overlay.style.bottom = '0';
+            this._overlay.style.left = '0';
+            this._overlay.style.right = '0';
+
+            this._overlay.appendChild(this._dropdown);
+            parent.appendChild(this._overlay);
+        } else if (this.blockStrategy === 'none') {
+            parent.appendChild(this._dropdown);
+        }
     }
 
     private _updateAppendedDropdownPosition() {
-        const parent = document.querySelector(this.appendTo) || document.body;
+        let parent;
+        if (this.blockStrategy === 'block') {
+            parent = this._overlay;
+        } else if (this.blockStrategy === 'none') {
+            parent = document.querySelector(this.appendTo) || document.body;
+        }
+
         this._dropdown.style.display = 'none';
         const selectRect: ClientRect = this._select.getBoundingClientRect();
         const boundingRect = parent.getBoundingClientRect();

--- a/src/ng-select/ng-dropdown-panel.component.ts
+++ b/src/ng-select/ng-dropdown-panel.component.ts
@@ -364,6 +364,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy, A
 
         if (this.blockStrategy === 'block') {
             this._overlay = this._renderer.createElement('div');
+            this._overlay.classList.add('ng-dropdown-panel-overlay');
             this._overlay.style.position = 'fixed';
             this._overlay.style.top = '0';
             this._overlay.style.bottom = '0';

--- a/src/ng-select/ng-select.component.html
+++ b/src/ng-select/ng-select.component.html
@@ -67,6 +67,7 @@
     [virtualScroll]="virtualScroll"
     [bufferAmount]="bufferAmount"
     [appendTo]="appendTo"
+    [blockStrategy]="blockStrategy"
     [position]="dropdownPosition"
     [headerTemplate]="headerTemplate"
     [footerTemplate]="footerTemplate"

--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -1,14 +1,21 @@
-import { async, ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { Component, DebugElement, ErrorHandler, NgZone, Type, ViewChild, ViewEncapsulation } from '@angular/core';
-import { ConsoleService } from './console.service';
+import { async, ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { getNgSelectElement, selectOption, TestsErrorHandler, tickAndDetectChanges, triggerKeyDownEvent } from '../testing/helpers';
-import { KeyCode, NgOption } from './ng-select.types';
+import { By } from '@angular/platform-browser';
+import { Subject } from 'rxjs';
+
+import {
+    getNgSelectElement,
+    selectOption,
+    TestsErrorHandler,
+    tickAndDetectChanges,
+    triggerKeyDownEvent
+} from '../testing/helpers';
 import { MockConsole, MockNgWindow, MockNgZone } from '../testing/mocks';
+import { ConsoleService } from './console.service';
 import { NgSelectComponent } from './ng-select.component';
 import { NgSelectModule } from './ng-select.module';
-import { Subject } from 'rxjs';
+import { KeyCode, NgOption } from './ng-select.types';
 import { WindowService } from './window.service';
 
 describe('NgSelectComponent', function () {
@@ -3104,6 +3111,26 @@ describe('NgSelectComponent', function () {
                 expect(dropdown.parentElement).toBe(document.body);
                 expect(dropdown.style.top).not.toBe('0px');
                 expect(dropdown.style.left).toBe('0px');
+            })
+        }));
+
+        it('should append dropdown to body, with blocking', async(() => {
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `<ng-select [items]="cities"
+                        appendTo="body"
+                        blockStrategy="block"
+                        [(ngModel)]="selectedCity">
+                </ng-select>`);
+
+            fixture.componentInstance.select.open();
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => {
+                const dropdown = <HTMLElement>document.querySelector('.ng-dropdown-panel');
+                const dropdownOverlay = <HTMLElement>document.querySelector('.ng-dropdown-panel-overlay');
+                expect(dropdown.parentElement).toBe(dropdownOverlay);
+                expect(dropdownOverlay.parentElement).toBe(document.body);
             })
         }));
 

--- a/src/ng-select/scroll-strategy/block-scroll-strategy.ts
+++ b/src/ng-select/scroll-strategy/block-scroll-strategy.ts
@@ -1,5 +1,3 @@
-import { Injectable } from '@angular/core';
-
 import { coerceCssPixelValue } from './css-pixel-value';
 import { ViewportRuler } from './viewport-ruler';
 
@@ -21,9 +19,6 @@ type ScrollBehaviorCSSStyleDeclaration = CSSStyleDeclaration & { scrollBehavior:
 /**
  * Strategy that will prevent the user from scrolling while the overlay is visible.
  */
-@Injectable({
-    providedIn: 'root'
-})
 export class BlockScrollStrategy {
     private _previousHTMLStyles = { top: '', left: '' };
     private _previousScrollPosition: { top: number, left: number };

--- a/src/ng-select/scroll-strategy/block-scroll-strategy.ts
+++ b/src/ng-select/scroll-strategy/block-scroll-strategy.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@angular/core';
+
+import { coerceCssPixelValue } from './css-pixel-value';
+import { ViewportRuler } from './viewport-ruler';
+
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Extended `CSSStyleDeclaration` that includes `scrollBehavior` which isn't part of the
+ * built-in TS typings. Once it is, this declaration can be removed safely.
+ * @docs-private
+ */
+type ScrollBehaviorCSSStyleDeclaration = CSSStyleDeclaration & { scrollBehavior: string };
+
+/**
+ * Strategy that will prevent the user from scrolling while the overlay is visible.
+ */
+@Injectable({
+    providedIn: 'root'
+})
+export class BlockScrollStrategy {
+    private _previousHTMLStyles = { top: '', left: '' };
+    private _previousScrollPosition: { top: number, left: number };
+    private _isEnabled = false;
+    private _document: Document;
+
+    constructor(private _viewportRuler: ViewportRuler, document: any) {
+        this._document = document;
+    }
+
+    /** Attaches this scroll strategy to an overlay. */
+    attach() { }
+
+    /** Blocks page-level scroll while the attached overlay is open. */
+    enable() {
+        if (this._canBeEnabled()) {
+            const root = this._document.documentElement!;
+
+            this._previousScrollPosition = this._viewportRuler.getViewportScrollPosition();
+
+            // Cache the previous inline styles in case the user had set them.
+            this._previousHTMLStyles.left = root.style.left || '';
+            this._previousHTMLStyles.top = root.style.top || '';
+
+            // Note: we're using the `html` node, instead of the `body`, because the `body` may
+            // have the user agent margin, whereas the `html` is guaranteed not to have one.
+            root.style.left = coerceCssPixelValue(-this._previousScrollPosition.left);
+            root.style.top = coerceCssPixelValue(-this._previousScrollPosition.top);
+            root.classList.add('cdk-global-scrollblock');
+            this._isEnabled = true;
+        }
+    }
+
+    /** Unblocks page-level scroll while the attached overlay is open. */
+    disable() {
+        if (this._isEnabled) {
+            const html = this._document.documentElement!;
+            const body = this._document.body!;
+            const htmlStyle = html.style as ScrollBehaviorCSSStyleDeclaration;
+            const bodyStyle = body.style as ScrollBehaviorCSSStyleDeclaration;
+            const previousHtmlScrollBehavior = htmlStyle.scrollBehavior || '';
+            const previousBodyScrollBehavior = bodyStyle.scrollBehavior || '';
+
+            this._isEnabled = false;
+
+            htmlStyle.left = this._previousHTMLStyles.left;
+            htmlStyle.top = this._previousHTMLStyles.top;
+            html.classList.remove('cdk-global-scrollblock');
+
+            // Disable user-defined smooth scrolling temporarily while we restore the scroll position.
+            // See https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior
+            htmlStyle.scrollBehavior = bodyStyle.scrollBehavior = 'auto';
+
+            window.scroll(this._previousScrollPosition.left, this._previousScrollPosition.top);
+
+            htmlStyle.scrollBehavior = previousHtmlScrollBehavior;
+            bodyStyle.scrollBehavior = previousBodyScrollBehavior;
+        }
+    }
+
+    private _canBeEnabled(): boolean {
+        // Since the scroll strategies can't be singletons, we have to use a global CSS class
+        // (`cdk-global-scrollblock`) to make sure that we don't try to disable global
+        // scrolling multiple times.
+        const html = this._document.documentElement!;
+
+        if (html.classList.contains('cdk-global-scrollblock') || this._isEnabled) {
+            return false;
+        }
+
+        const body = this._document.body;
+        const viewport = this._viewportRuler.getViewportSize();
+        return body.scrollHeight > viewport.height || body.scrollWidth > viewport.width;
+    }
+}

--- a/src/ng-select/scroll-strategy/css-pixel-value.ts
+++ b/src/ng-select/scroll-strategy/css-pixel-value.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Coerces a value to a CSS pixel value. */
+export function coerceCssPixelValue(value: any): string {
+    if (value == null) {
+        return '';
+    }
+
+    return typeof value === 'string' ? value : `${value}px`;
+}

--- a/src/ng-select/scroll-strategy/platform.ts
+++ b/src/ng-select/scroll-strategy/platform.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
+
+// Whether the current platform supports the V8 Break Iterator. The V8 check
+// is necessary to detect all Blink based browsers.
+let hasV8BreakIterator: boolean;
+
+// We need a try/catch around the reference to `Intl`, because accessing it in some cases can
+// cause IE to throw. These cases are tied to particular versions of Windows and can happen if
+// the consumer is providing a polyfilled `Map`. See:
+// https://github.com/Microsoft/ChakraCore/issues/3189
+// https://github.com/angular/components/issues/15687
+try {
+  hasV8BreakIterator = (typeof Intl !== 'undefined' && (Intl as any).v8BreakIterator);
+} catch {
+  hasV8BreakIterator = false;
+}
+
+/**
+ * Service to detect the current platform by comparing the userAgent strings and
+ * checking browser-specific global properties.
+ */
+@Injectable({providedIn: 'root'})
+export class Platform {
+  /**
+   * Whether the Angular application is being rendered in the browser.
+   * We want to use the Angular platform check because if the Document is shimmed
+   * without the navigator, the following checks will fail. This is preferred because
+   * sometimes the Document may be shimmed without the user's knowledge or intention
+   */
+  isBrowser: boolean = this._platformId ?
+      isPlatformBrowser(this._platformId) : typeof document === 'object' && !!document;
+
+  /** Whether the current browser is Microsoft Edge. */
+  EDGE: boolean = this.isBrowser && /(edge)/i.test(navigator.userAgent);
+
+  /** Whether the current rendering engine is Microsoft Trident. */
+  TRIDENT: boolean = this.isBrowser && /(msie|trident)/i.test(navigator.userAgent);
+
+  /** Whether the current rendering engine is Blink. */
+  // EdgeHTML and Trident mock Blink specific things and need to be excluded from this check.
+  BLINK: boolean = this.isBrowser && (!!((window as any).chrome || hasV8BreakIterator) &&
+      typeof CSS !== 'undefined' && !this.EDGE && !this.TRIDENT);
+
+  /** Whether the current rendering engine is WebKit. */
+  // Webkit is part of the userAgent in EdgeHTML, Blink and Trident. Therefore we need to
+  // ensure that Webkit runs standalone and is not used as another engine's base.
+  WEBKIT: boolean = this.isBrowser &&
+      /AppleWebKit/i.test(navigator.userAgent) && !this.BLINK && !this.EDGE && !this.TRIDENT;
+
+  /** Whether the current platform is Apple iOS. */
+  IOS: boolean = this.isBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+      !('MSStream' in window);
+
+  /** Whether the current browser is Firefox. */
+  // It's difficult to detect the plain Gecko engine, because most of the browsers identify
+  // them self as Gecko-like browsers and modify the userAgent's according to that.
+  // Since we only cover one explicit Firefox case, we can simply check for Firefox
+  // instead of having an unstable check for Gecko.
+  FIREFOX: boolean = this.isBrowser && /(firefox|minefield)/i.test(navigator.userAgent);
+
+  /** Whether the current platform is Android. */
+  // Trident on mobile adds the android platform to the userAgent to trick detections.
+  ANDROID: boolean = this.isBrowser && /android/i.test(navigator.userAgent) && !this.TRIDENT;
+
+  /** Whether the current browser is Safari. */
+  // Safari browsers will include the Safari keyword in their userAgent. Some browsers may fake
+  // this and just place the Safari keyword in the userAgent. To be more safe about Safari every
+  // Safari browser should also use Webkit as its layout engine.
+  SAFARI: boolean = this.isBrowser && /safari/i.test(navigator.userAgent) && this.WEBKIT;
+
+  /**
+   * @breaking-change 8.0.0 remove optional decorator
+   */
+  constructor(@Optional() @Inject(PLATFORM_ID) private _platformId?: Object) {
+}
+}

--- a/src/ng-select/scroll-strategy/viewport-ruler.ts
+++ b/src/ng-select/scroll-strategy/viewport-ruler.ts
@@ -1,0 +1,151 @@
+import { Injectable, NgZone, OnDestroy, Optional, SkipSelf } from '@angular/core';
+import { fromEvent, merge, Observable, of as observableOf, Subscription } from 'rxjs';
+import { auditTime } from 'rxjs/operators';
+
+import { Platform } from './platform';
+
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Time in ms to throttle the resize events by default. */
+export const DEFAULT_RESIZE_TIME = 20;
+
+/** Object that holds the scroll position of the viewport in each direction. */
+export interface ViewportScrollPosition {
+    top: number;
+    left: number;
+}
+
+/**
+ * Simple utility for getting the bounds of the browser viewport.
+ * @docs-private
+ */
+@Injectable({ providedIn: 'root' })
+export class ViewportRuler implements OnDestroy {
+    /** Cached viewport dimensions. */
+    private _viewportSize: { width: number; height: number };
+
+    /** Stream of viewport change events. */
+    private _change: Observable<Event>;
+
+    /** Subscription to streams that invalidate the cached viewport dimensions. */
+    private _invalidateCache: Subscription;
+
+    constructor(private _platform: Platform, ngZone: NgZone) {
+        ngZone.runOutsideAngular(() => {
+            this._change = _platform.isBrowser ?
+                merge(fromEvent(window, 'resize'), fromEvent(window, 'orientationchange')) :
+                observableOf();
+
+            // Note that we need to do the subscription inside `runOutsideAngular`
+            // since subscribing is what causes the event listener to be added.
+            this._invalidateCache = this.change().subscribe(() => this._updateViewportSize());
+        });
+    }
+
+    ngOnDestroy() {
+        this._invalidateCache.unsubscribe();
+    }
+
+    /** Returns the viewport's width and height. */
+    getViewportSize(): Readonly<{ width: number, height: number }> {
+        if (!this._viewportSize) {
+            this._updateViewportSize();
+        }
+
+        const output = { width: this._viewportSize.width, height: this._viewportSize.height };
+
+        // If we're not on a browser, don't cache the size since it'll be mocked out anyway.
+        if (!this._platform.isBrowser) {
+            this._viewportSize = null!;
+        }
+
+        return output;
+    }
+
+    /** Gets a ClientRect for the viewport's bounds. */
+    getViewportRect(): ClientRect {
+        // Use the document element's bounding rect rather than the window scroll properties
+        // (e.g. pageYOffset, scrollY) due to in issue in Chrome and IE where window scroll
+        // properties and client coordinates (boundingClientRect, clientX/Y, etc.) are in different
+        // conceptual viewports. Under most circumstances these viewports are equivalent, but they
+        // can disagree when the page is pinch-zoomed (on devices that support touch).
+        // See https://bugs.chromium.org/p/chromium/issues/detail?id=489206#c4
+        // We use the documentElement instead of the body because, by default (without a css reset)
+        // browsers typically give the document body an 8px margin, which is not included in
+        // getBoundingClientRect().
+        const scrollPosition = this.getViewportScrollPosition();
+        const { width, height } = this.getViewportSize();
+
+        return {
+            top: scrollPosition.top,
+            left: scrollPosition.left,
+            bottom: scrollPosition.top + height,
+            right: scrollPosition.left + width,
+            height,
+            width,
+        };
+    }
+
+    /** Gets the (top, left) scroll position of the viewport. */
+    getViewportScrollPosition(): ViewportScrollPosition {
+        // While we can get a reference to the fake document
+        // during SSR, it doesn't have getBoundingClientRect.
+        if (!this._platform.isBrowser) {
+            return { top: 0, left: 0 };
+        }
+
+        // The top-left-corner of the viewport is determined by the scroll position of the document
+        // body, normally just (scrollLeft, scrollTop). However, Chrome and Firefox disagree about
+        // whether `document.body` or `document.documentElement` is the scrolled element, so reading
+        // `scrollTop` and `scrollLeft` is inconsistent. However, using the bounding rect of
+        // `document.documentElement` works consistently, where the `top` and `left` values will
+        // equal negative the scroll position.
+        const documentElement = document.documentElement!;
+        const documentRect = documentElement.getBoundingClientRect();
+
+        const top = -documentRect.top || document.body.scrollTop || window.scrollY ||
+            documentElement.scrollTop || 0;
+
+        const left = -documentRect.left || document.body.scrollLeft || window.scrollX ||
+            documentElement.scrollLeft || 0;
+
+        return { top, left };
+    }
+
+    /**
+     * Returns a stream that emits whenever the size of the viewport changes.
+     * @param throttleTime Time in milliseconds to throttle the stream.
+     */
+    change(throttleTime: number = DEFAULT_RESIZE_TIME): Observable<Event> {
+        return throttleTime > 0 ? this._change.pipe(auditTime(throttleTime)) : this._change;
+    }
+
+    /** Updates the cached viewport size. */
+    private _updateViewportSize() {
+        this._viewportSize = this._platform.isBrowser ?
+            { width: window.innerWidth, height: window.innerHeight } :
+            { width: 0, height: 0 };
+    }
+}
+
+
+/** @docs-private @deprecated @breaking-change 8.0.0 */
+export function VIEWPORT_RULER_PROVIDER_FACTORY(parentRuler: ViewportRuler,
+    platform: Platform,
+    ngZone: NgZone) {
+    return parentRuler || new ViewportRuler(platform, ngZone);
+}
+
+/** @docs-private @deprecated @breaking-change 8.0.0 */
+export const VIEWPORT_RULER_PROVIDER = {
+    // If there is already a ViewportRuler available, use that. Otherwise, provide a new one.
+    provide: ViewportRuler,
+    deps: [[new Optional(), new SkipSelf(), ViewportRuler], Platform, NgZone],
+    useFactory: VIEWPORT_RULER_PROVIDER_FACTORY
+};

--- a/src/themes/default.theme.scss
+++ b/src/themes/default.theme.scss
@@ -8,6 +8,12 @@ $ng-select-bg: #ffffff !default;
 $ng-select-selected: lighten($ng-select-highlight, 46);
 $ng-select-marked: lighten($ng-select-highlight, 48);
 
+.cdk-global-scrollblock {
+    position: fixed;
+    width: 100%;
+    overflow-y: scroll;
+}
+
 .ng-select {
     &.ng-select-opened {
         > .ng-select-container {

--- a/src/themes/material.theme.scss
+++ b/src/themes/material.theme.scss
@@ -9,6 +9,12 @@ $ng-select-disabled-text: rgba(black, 0.38) !default;
 $ng-select-divider: rgba(black, 0.12) !default;
 $ng-select-bg: #ffffff !default;
 
+.cdk-global-scrollblock {
+    position: fixed;
+    width: 100%;
+    overflow-y: scroll;
+}
+
 .ng-select {
     padding-bottom: 1.25em;
     &.ng-select-disabled {


### PR DESCRIPTION
- Added logic which is essentially a clone of angular material's block strategy, based on this comment (https://github.com/ng-select/ng-select/issues/1130#issuecomment-491865228) where it was confirmed that this is supported by material.

for #1130

**Please note**
I have essentially copied files from @angular/material/cdk. I would please like some feedback regarding that from a maintainer, on whether they are okay with this, or whether angular material's cdk should rather be pulled in.