### PR TITLE
Added readonly attribute to the ng-select.

### DIFF
--- a/src/ng-select/ng-select.component.html
+++ b/src/ng-select/ng-select.component.html
@@ -29,7 +29,7 @@
                    [attr.tabindex]="tabIndex"
                    [attr.autocorrect]="autoCorrect"
                    [attr.autocapitalize]="autoCapitalize"
-                   [readOnly]="!searchable || itemsList.maxItemsSelected"
+                   [readOnly]="!searchable || itemsList.maxItemsSelected || readonly"
                    [disabled]="disabled"
                    [value]="filterValue ? filterValue : ''"
                    (input)="filter(filterInput.value)"

--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -105,6 +105,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() trackByFn = null;
     @Input() excludeGroupsFromDefaultSelection = false;
     @Input() clearOnBackspace = true;
+    @Input() readonly = false;
 
     @Input() labelForId = null;
     @Input() autoCorrect: AutoCorrect = 'off';
@@ -382,7 +383,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     open() {
-        if (this.disabled || this.isOpen || this.itemsList.maxItemsSelected || this._manualOpen) {
+        if (this.disabled || this.isOpen || this.itemsList.maxItemsSelected || this._manualOpen || this.readonly) {
             return;
         }
 
@@ -524,7 +525,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     onInputFocus($event) {
-        if (this.focused) {
+        if (this.focused || this.readonly) {
             return;
         }
 


### PR DESCRIPTION
Maybe I dismissed something important, but this fix added an ability to add 'readonly' attribute to the ng-select.
Fixes #786 an issue.