### PR TITLE
fix: avoid &amp in ng-select drop down

### DIFF
--- a/src/ng-select/ng-select.component.html
+++ b/src/ng-select/ng-select.component.html
@@ -94,7 +94,7 @@
                 [attr.id]="item?.htmlId">
 
             <ng-template #defaultOptionTemplate>
-                <span class="ng-option-label">{{item.label}}</span>
+                <span class="ng-option-label" innerHTML="{{item.label}}"></span>
             </ng-template>
 
             <ng-template


### PR DESCRIPTION
Fix to avoid &amp in ng-select dropdown. ng-option doesn't recognize '&' as HTML value, it adds '& amp;' instead of the & symbol.