### PR TITLE
Fix cursor style on input field

### DIFF
--- a/src/ng-select/ng-select.component.scss
+++ b/src/ng-select/ng-select.component.scss
@@ -68,7 +68,6 @@
                     border: 0 none;
                     box-shadow: none;
                     outline: none;
-                    cursor: default;
                     width: 100%;
                     &::-ms-clear {
                         display: none;


### PR DESCRIPTION
There is no need for this element to have `cursor: default;`, it overrides the default input style.