### PR TITLE
Display no items when hideSelected is true

### DIFF
--- a/src/ng-select/items-list.ts
+++ b/src/ng-select/items-list.ts
@@ -42,7 +42,7 @@ export class ItemsList {
     }
 
     get noItemsToSelect(): boolean {
-        return this._ngSelect.hideSelected && this._items.length >0 && this._items.length === this.selectedItems.length;
+        return this._ngSelect.hideSelected && this._items.length > 0 && this._items.length === this.selectedItems.length;
     }
 
     get maxItemsSelected(): boolean {

--- a/src/ng-select/items-list.ts
+++ b/src/ng-select/items-list.ts
@@ -42,7 +42,7 @@ export class ItemsList {
     }
 
     get noItemsToSelect(): boolean {
-        return this._ngSelect.hideSelected && this._items.length === this.selectedItems.length;
+        return this._ngSelect.hideSelected && this._items.length >0 && this._items.length === this.selectedItems.length;
     }
 
     get maxItemsSelected(): boolean {

--- a/src/ng-select/ng-select.component.spec.ts
+++ b/src/ng-select/ng-select.component.spec.ts
@@ -1225,6 +1225,15 @@ describe('NgSelectComponent', () => {
                 const text = fixture.debugElement.query(By.css('.ng-option')).nativeElement.innerHTML;
                 expect(text).toContain('No items found');
             }));
+            it('should open empty dropdown if no items and hideSelected is true', fakeAsync(() => {
+                fixture.componentInstance.cities = [];
+                fixture.componentInstance.hideSelected = true ;
+                tickAndDetectChanges(fixture);
+                triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
+                tickAndDetectChanges(fixture);
+                const text = fixture.debugElement.query(By.css('.ng-option')).nativeElement.innerHTML;
+                expect(text).toContain('No items found');
+            }));
 
             it('should open dropdown with loading message', fakeAsync(() => {
                 fixture.componentInstance.cities = [];


### PR DESCRIPTION
This PR fix an issue when there are no items and hideSelected is set to true. Now the select component will be able to show `no items found` message.