### PR TITLE
use regex with multiple return to highlight multiple search terms

### DIFF
--- a/src/ng-option-highlight/lib/ng-option-highlight.directive.spec.ts
+++ b/src/ng-option-highlight/lib/ng-option-highlight.directive.spec.ts
@@ -7,7 +7,10 @@ import { By } from '@angular/platform-browser';
     template: `
         <span id="test1" [ngOptionHighlight]="term">My text is highlighted</span>
         <span id="test2" [ngOptionHighlight]="term">My text is not highlighted</span>
-        <span id="test3" *ngIf="showNew" [ngOptionHighlight]="term">New label</span>
+        <span id="test3" [ngOptionHighlight]="term">My text is highlighted</span>
+        <span id="test4" [ngOptionHighlight]="term">My text is highlighted text</span>
+        <span id="test5" [ngOptionHighlight]="term">My ťëxť is highlighted text</span>
+        <span id="test6" *ngIf="showNew" [ngOptionHighlight]="term">New label</span>
     `
 })
 class TestComponent {
@@ -27,16 +30,16 @@ describe('NgOptionHighlightDirective', () => {
         fixture.detectChanges();
     });
 
-    it('should have two elements with highlight directive', () => {
+    it('should have five elements with highlight directive', () => {
         const highlightDirectives = fixture.debugElement.queryAll(By.directive(NgOptionHighlightDirective));
-        expect(highlightDirectives.length).toBe(2);
+        expect(highlightDirectives.length).toBe(5);
     });
 
     it('should have one element with highlighted text when term matching', () => {
         const span = fixture.debugElement.query(By.css('#test1'));
-        fixture.componentInstance.term = 'is high';
+        fixture.componentInstance.term = 'highlighted';
         fixture.detectChanges();
-        expect(span.nativeElement.querySelector('.highlighted').innerHTML).toBe('is high');
+        expect(span.nativeElement.querySelector('.highlighted').innerHTML).toBe('highlighted');
         expect(span.nativeElement.textContent).toBe('My text is highlighted');
     });
 
@@ -48,12 +51,29 @@ describe('NgOptionHighlightDirective', () => {
         expect(span.nativeElement.innerHTML).toBe('My text is not highlighted');
     });
 
+    it('should have multiple elements with highlighted text when term matching', () => {
+        const span = fixture.debugElement.query(By.css('#test3'));
+        fixture.componentInstance.term = 'text highlighted';
+        fixture.detectChanges();
+        expect(span.nativeElement.querySelectorAll('.highlighted')[0].innerHTML).toBe('text');
+        expect(span.nativeElement.querySelectorAll('.highlighted')[1].innerHTML).toBe('highlighted');
+        expect(span.nativeElement.textContent).toBe('My text is highlighted');
+    });
+
+    it('Highlights special characters', () => {
+        const span = fixture.debugElement.query(By.css('#test5'));
+        fixture.componentInstance.term = 'ťëxť';
+        fixture.detectChanges();
+        expect(span.nativeElement.querySelector('.highlighted').innerHTML).toBe('ťëxť');
+        expect(span.nativeElement.textContent).toBe('My ťëxť is highlighted text');
+    });
+
     it('should highlight text when label changed',  () => {
         fixture.componentInstance.term = 'new';
         fixture.detectChanges();
         fixture.componentInstance.showNew = true;
         fixture.detectChanges();
-        const span = fixture.debugElement.query(By.css('#test3'));
+        const span = fixture.debugElement.query(By.css('#test6'));
         expect(span.nativeElement.querySelector('.highlighted').innerHTML).toBe('New');
         expect(span.nativeElement.textContent).toBe('New label');
     });

--- a/src/ng-option-highlight/lib/ng-option-highlight.directive.spec.ts
+++ b/src/ng-option-highlight/lib/ng-option-highlight.directive.spec.ts
@@ -37,9 +37,10 @@ describe('NgOptionHighlightDirective', () => {
 
     it('should have one element with highlighted text when term matching', () => {
         const span = fixture.debugElement.query(By.css('#test1'));
-        fixture.componentInstance.term = 'highlighted';
+        fixture.componentInstance.term = 'is high';
         fixture.detectChanges();
-        expect(span.nativeElement.querySelector('.highlighted').innerHTML).toBe('highlighted');
+        expect(span.nativeElement.querySelectorAll('.highlighted')[0].innerHTML).toBe('is');
+        expect(span.nativeElement.querySelectorAll('.highlighted')[1].innerHTML).toBe('high');
         expect(span.nativeElement.textContent).toBe('My text is highlighted');
     });
 

--- a/src/ng-option-highlight/lib/ng-option-highlight.directive.spec.ts
+++ b/src/ng-option-highlight/lib/ng-option-highlight.directive.spec.ts
@@ -8,9 +8,8 @@ import { By } from '@angular/platform-browser';
         <span id="test1" [ngOptionHighlight]="term">My text is highlighted</span>
         <span id="test2" [ngOptionHighlight]="term">My text is not highlighted</span>
         <span id="test3" [ngOptionHighlight]="term">My text is highlighted</span>
-        <span id="test4" [ngOptionHighlight]="term">My text is highlighted text</span>
-        <span id="test5" [ngOptionHighlight]="term">My ťëxť is highlighted text</span>
-        <span id="test6" *ngIf="showNew" [ngOptionHighlight]="term">New label</span>
+        <span id="test4" [ngOptionHighlight]="term">My ťëxť is highlighted text</span>
+        <span id="test5" *ngIf="showNew" [ngOptionHighlight]="term">New label</span>
     `
 })
 class TestComponent {
@@ -62,7 +61,7 @@ describe('NgOptionHighlightDirective', () => {
     });
 
     it('Highlights special characters', () => {
-        const span = fixture.debugElement.query(By.css('#test5'));
+        const span = fixture.debugElement.query(By.css('#test4'));
         fixture.componentInstance.term = 'ťëxť';
         fixture.detectChanges();
         expect(span.nativeElement.querySelector('.highlighted').innerHTML).toBe('ťëxť');
@@ -74,7 +73,7 @@ describe('NgOptionHighlightDirective', () => {
         fixture.detectChanges();
         fixture.componentInstance.showNew = true;
         fixture.detectChanges();
-        const span = fixture.debugElement.query(By.css('#test6'));
+        const span = fixture.debugElement.query(By.css('#test5'));
         expect(span.nativeElement.querySelector('.highlighted').innerHTML).toBe('New');
         expect(span.nativeElement.textContent).toBe('New label');
     });

--- a/src/ng-option-highlight/lib/ng-option-highlight.directive.ts
+++ b/src/ng-option-highlight/lib/ng-option-highlight.directive.ts
@@ -44,17 +44,9 @@ export class NgOptionHighlightDirective implements OnChanges, AfterViewInit {
             return;
         }
 
-        const indexOfTerm = searchHelper.stripSpecialChars(label)
-            .toLowerCase()
-            .indexOf(searchHelper.stripSpecialChars(this.term).toLowerCase());
-        if (indexOfTerm > -1) {
-            this._setInnerHtml(
-                label.substring(0, indexOfTerm)
-                + `<span class="highlighted">${label.substr(indexOfTerm, this.term.length)}</span>`
-                + label.substring(indexOfTerm + this.term.length, label.length));
-        } else {
-            this._setInnerHtml(label);
-        }
+        const alternationString = this.term.replace(' ', '|')
+        const termRegex = new RegExp(alternationString, 'gi')
+        this._setInnerHtml(label.replace(termRegex, `<span class=\"highlighted\">$&</span>`))
     }
 
     private get _canHighlight() {


### PR DESCRIPTION
Contributing to #739, highlighting each instance of the search term

I'm not sure about the expected behavior of special characters, let me know if I need to change anything