### PR TITLE
groupBy doesn't show the first group

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -206,7 +206,8 @@ export class ItemsList {
         if (lastMarkedIndex > -1) {
             this._markedIndex = lastMarkedIndex;
         } else {
-            this._markedIndex = markDefault && !isDefined(this._ngSelect.groupBy) ? this.filteredItems.findIndex(x => !x.disabled) : -1;
+            this._markedIndex = markDefault && (!isDefined(this._ngSelect.groupBy) || this._ngSelect.selectableGroup)
+                ? this.filteredItems.findIndex(x => !x.disabled) : -1;
         }
     }
 

--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -206,7 +206,7 @@ export class ItemsList {
         if (lastMarkedIndex > -1) {
             this._markedIndex = lastMarkedIndex;
         } else {
-            this._markedIndex = markDefault ? this.filteredItems.findIndex(x => !x.disabled) : -1;
+            this._markedIndex = markDefault && !isDefined(this._ngSelect.groupBy) ? this.filteredItems.findIndex(x => !x.disabled) : -1;
         }
     }
 


### PR DESCRIPTION
This quick fix does mean that the first non-disabled item in a grouped list may not be selected by default.
Fixes #1273 