### PR TITLE
fix: styles for "Append to element" example

### DIFF
--- a/src/demo/app/examples/append-to-example/append-to-example.component.scss
+++ b/src/demo/app/examples/append-to-example/append-to-example.component.scss
@@ -1,5 +1,4 @@
 .overflow-box {
-    widht: 300px;
     padding: 5px;
     height: 100px;
     border: 1px solid #999;


### PR DESCRIPTION
There was a misspelling in the attribute "width". Looks like it is not necessary.