### PR TITLE
feat: Append appendTo NgSelectConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ typically in your root component, and customize the values of its properties in 
 ```js
   constructor(private config: NgSelectConfig) {
       this.config.notFoundText = 'Custom not found';
+      this.config.appendTo = 'body';
   }
 ```
 ### SystemJS

--- a/src/demo/app/app.component.ts
+++ b/src/demo/app/app.component.ts
@@ -23,6 +23,8 @@ export class AppComponent {
         private config: NgSelectConfig
     ) {
         this.config.placeholder = 'Select item';
+        // This could be useful if you want to use appendTo in entire application without explicitly defining it. (eg: appendTo = 'body')
+        this.config.appendTo = null; 
     }
 
     ngOnInit() {

--- a/src/ng-select/lib/config.service.ts
+++ b/src/ng-select/lib/config.service.ts
@@ -10,4 +10,5 @@ export class NgSelectConfig {
     clearAllText = 'Clear all';
     disableVirtualScroll = true;
     openOnEnter = true;
+    appendTo: string;
 }

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -896,5 +896,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             ? this.virtualScroll
             : isDefined(config.disableVirtualScroll) ? !config.disableVirtualScroll : false;
         this.openOnEnter = isDefined(this.openOnEnter) ? this.openOnEnter : config.openOnEnter;
+        this.appendTo = this.appendTo || config.appendTo;
     }
 }


### PR DESCRIPTION
This PR provides feature as expected in #1276

Provided `appendTo` option globally. 
Also, If `appendTo` property is available in `ng-select` template, then the provided value will be taken as value.