### PR TITLE
feat: bindValue as global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ typically in your root component, and customize the values of its properties in 
   constructor(private config: NgSelectConfig) {
       this.config.notFoundText = 'Custom not found';
       this.config.appendTo = 'body';
+      // set the bindValue to global config when you use the same 
+      // bindValue is most of the place. 
+      // You can also override bindValue for the specified template 
+      // by defining `bindValue` as property
+      // Eg : <ng-select bindValue="some-new-value"></ng-select>
+      this.config.bindValue = 'value';
   }
 ```
 ### SystemJS

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ typically in your root component, and customize the values of its properties in 
       this.config.notFoundText = 'Custom not found';
       this.config.appendTo = 'body';
       // set the bindValue to global config when you use the same 
-      // bindValue is most of the place. 
+      // bindValue in most of the place. 
       // You can also override bindValue for the specified template 
       // by defining `bindValue` as property
       // Eg : <ng-select bindValue="some-new-value"></ng-select>

--- a/src/demo/app/app.component.ts
+++ b/src/demo/app/app.component.ts
@@ -25,6 +25,10 @@ export class AppComponent {
         this.config.placeholder = 'Select item';
         // This could be useful if you want to use appendTo in entire application without explicitly defining it. (eg: appendTo = 'body')
         this.config.appendTo = null; 
+        // set the bindValue to global config when you use the same bindValue is most of the place. 
+        // You can also override bindValue for the specified template by defining `bindValue` as property
+        // Eg : <ng-select bindValue="some-new-value"></ng-select>
+        // this.config.bindValue = 'value';
     }
 
     ngOnInit() {

--- a/src/demo/app/app.component.ts
+++ b/src/demo/app/app.component.ts
@@ -25,7 +25,7 @@ export class AppComponent {
         this.config.placeholder = 'Select item';
         // This could be useful if you want to use appendTo in entire application without explicitly defining it. (eg: appendTo = 'body')
         this.config.appendTo = null; 
-        // set the bindValue to global config when you use the same bindValue is most of the place. 
+        // set the bindValue to global config when you use the same bindValue in most of the place. 
         // You can also override bindValue for the specified template by defining `bindValue` as property
         // Eg : <ng-select bindValue="some-new-value"></ng-select>
         // this.config.bindValue = 'value';

--- a/src/ng-select/lib/config.service.ts
+++ b/src/ng-select/lib/config.service.ts
@@ -11,4 +11,5 @@ export class NgSelectConfig {
     disableVirtualScroll = true;
     openOnEnter = true;
     appendTo: string;
+    bindValue: string;
 }

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -170,6 +170,86 @@ describe('NgSelectComponent', () => {
             })]);
         }));
 
+        it('should set items correctly after ngModel set first when bindValue is used from NgSelectConfig', fakeAsync(() => {
+            const config = new NgSelectConfig();
+            config.bindValue = 'id';
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `<ng-select [items]="cities"
+                        bindLabel="name"
+                        [clearable]="true"
+                        [(ngModel)]="selectedCityId">
+                </ng-select>`,
+                config
+                );
+
+            fixture.componentInstance.cities = [];
+            fixture.componentInstance.selectedCityId = 7;
+            tickAndDetectChanges(fixture);
+
+            fixture.componentInstance.cities = [{ id: 7, name: 'Pailgis' }];
+            tickAndDetectChanges(fixture);
+
+            select = fixture.componentInstance.select;
+            expect(select.selectedItems[0]).toBe(select.itemsList.items[0]);
+            expect(select.selectedItems).toEqual([jasmine.objectContaining({
+                value: { id: 7, name: 'Pailgis' }
+            })]);
+        }));
+
+        it('should not apply global bindValue from NgSelectConfig if bindValue prop explicitly provided in template', fakeAsync(() => {
+            const config = new NgSelectConfig();
+            config.bindValue = 'globalbindvalue';
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `<ng-select [items]="cities"
+                        bindLabel="name"
+                        bindValue="id"
+                        [clearable]="true"
+                        [(ngModel)]="selectedCityId">
+                </ng-select>`,
+                config
+                );
+
+            fixture.componentInstance.cities = [];
+            fixture.componentInstance.selectedCityId = 7;
+            tickAndDetectChanges(fixture);
+
+            fixture.componentInstance.cities = [{ id: 7, name: 'Pailgis' }];
+            tickAndDetectChanges(fixture);
+
+            select = fixture.componentInstance.select;
+            expect(select.selectedItems[0]).toBe(select.itemsList.items[0]);
+            expect(select.selectedItems).toEqual([jasmine.objectContaining({
+                value: { id: 7, name: 'Pailgis' }
+            })]);
+        }));
+
+        it('should bind whole object as value when bindValue prop is specified with empty string in template', fakeAsync(() => {
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `<ng-select [items]="cities"
+                        bindLabel="name"
+                        bindValue=""
+                        [clearable]="true"
+                        [(ngModel)]="selectedCity">
+                </ng-select>`
+                );
+
+            fixture.componentInstance.cities = [];
+            fixture.componentInstance.selectedCity = { id: 7, name: 'Pailgis' };
+            tickAndDetectChanges(fixture);
+
+            fixture.componentInstance.cities = [{ id: 7, name: 'Pailgis' }];
+            tickAndDetectChanges(fixture);
+
+            select = fixture.componentInstance.select;
+            expect(select.selectedItems[0]).toBe(select.itemsList.items[0]);
+            expect(select.selectedItems).toEqual([jasmine.objectContaining({
+                value: { id: 7, name: 'Pailgis' }
+            })]);
+        }));
+
         it('should map label correctly', fakeAsync(() => {
             const fixture = createTestingModule(
                 NgSelectTestCmp,

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -910,5 +910,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             : isDefined(config.disableVirtualScroll) ? !config.disableVirtualScroll : false;
         this.openOnEnter = isDefined(this.openOnEnter) ? this.openOnEnter : config.openOnEnter;
         this.appendTo = this.appendTo || config.appendTo;
+        this.bindValue = this.bindValue || config.bindValue;
     }
 }


### PR DESCRIPTION
This feature has the ability to add `bindValue` as a global config. Also, if needed, one can override bindValue for the specified template by defining `bindValue` as property.

`<ng-select     
       bindValue="some-new-value">
   </ng-select>`

This closes the #516 feature request. 