### PR TITLE
feat: Allow duplicate tags based on configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ map: {
 | ------------- | ------------- | ------------- | ------------- | ------------- |
 | [addTag] | `boolean \| ((term: string) => any \| Promise<any>)`  | `false` | no | Allows to create custom options. |
 | addTagText | `string` | `Add item` | no | Set custom text when using tagging |
+| allowDuplicateTag | `boolean` | `false` | no | Allow duplicate tag when using tagging |
 | appendTo | `string` |  null | no | Append dropdown to body or any other element using css selector. For correct positioning `body` should have `position:relative` |
 | bindValue  | `string` | `-` | no | Object property to use for selected model. By default binds to whole object. |
 | bindLabel  | `string` | `label` | no | Object property to use for label. Default `label`  |

--- a/src/demo/app/examples/examples.module.ts
+++ b/src/demo/app/examples/examples.module.ts
@@ -45,6 +45,7 @@ import { TemplateOptgroupExampleComponent } from './template-optgroup-example/te
 import { TemplateOptionExampleComponent } from './template-option-example/template-option-example.component';
 import { TemplateSearchExampleComponent } from './template-search-example/template-search-example.component';
 import { VirtualScrollExampleComponent } from './virtual-scroll-example/virtual-scroll-example.component';
+import { TagsAllowDuplicateExampleComponent } from './tags-allow-duplicate-example/tags-allow-duplicate.component';
 
 
 const examples = [DataSourceBackendExampleComponent,
@@ -62,6 +63,7 @@ const examples = [DataSourceBackendExampleComponent,
     SearchCustomExampleComponent,
     SearchAutocompleteExampleComponent,
     TagsDefaultExampleComponent,
+    TagsAllowDuplicateExampleComponent,
     TagsCustomExampleComponent,
     TagsBackendExampleComponent,
     TagsClosedDropdownExampleComponent,

--- a/src/demo/app/examples/examples.ts
+++ b/src/demo/app/examples/examples.ts
@@ -40,6 +40,7 @@ import { GroupFunctionExampleComponent } from './group-function-example/group-fu
 import { GroupSelectableExampleComponent } from './group-selectable-example/group-selectable-example.component';
 import { GroupSelectableHiddenExampleComponent } from './group-selectable-hidden-example/group-selectable-hidden-example.component';
 import { GroupChildrenExampleComponent } from './group-children-example/group-children-example.component';
+import { TagsAllowDuplicateExampleComponent } from './tags-allow-duplicate-example/tags-allow-duplicate.component';
 
 export interface Example {
     component: any;
@@ -110,6 +111,10 @@ export const EXAMPLE_COMPONENTS: { [key: string]: Example } = {
     'tags-custom-example': {
         component: TagsCustomExampleComponent,
         title: 'Custom tags'
+    },
+    'tags-allow-duplicate-example': {
+        component: TagsAllowDuplicateExampleComponent,
+        title: 'Allow Duplicate tags'
     },
     'tags-backend-example': {
         component: TagsBackendExampleComponent,

--- a/src/demo/app/examples/tags-allow-duplicate-example/tags-allow-duplicate.component.html
+++ b/src/demo/app/examples/tags-allow-duplicate-example/tags-allow-duplicate.component.html
@@ -1,0 +1,10 @@
+<ng-select [items]="companies"
+           [addTag]="true"
+           [allowDuplicateTag]="true"
+           multiple="true"
+           bindLabel="name"
+           [(ngModel)]="selectedCompanies">
+</ng-select>
+
+<br>
+Selected value: {{selectedCompanies | json}}

--- a/src/demo/app/examples/tags-allow-duplicate-example/tags-allow-duplicate.component.ts
+++ b/src/demo/app/examples/tags-allow-duplicate-example/tags-allow-duplicate.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'tags-allow-duplicate-example',
+    templateUrl: './tags-allow-duplicate.component.html'
+})
+export class TagsAllowDuplicateExampleComponent implements OnInit {
+
+    selectedCompanies;
+    companies: any[] = [];
+    companiesNames = ['Uber', 'Microsoft', 'Flexigen'];
+
+    ngOnInit() {
+        this.companiesNames.forEach((c, i) => {
+            this.companies.push({ id: i, name: c });
+        });
+    }
+}

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2264,6 +2264,31 @@ describe('NgSelectComponent', () => {
                 select.searchTerm = '   ';
                 expect(select.showAddTag).toBeFalsy();
             });
+
+            it('should allow duplicate tag if allowDuplicateTag prop is set as true', fakeAsync(() => {
+                select.searchTerm = 'Vilnius';
+                select.allowDuplicateTag = true;
+                select.isOpen = true;
+                tickAndDetectChanges(fixture);
+                expect(select.showAddTag).toBeTruthy();
+            }));
+
+            it('should not allow duplicate tag if allowDuplicateTag prop is set as false', fakeAsync(() => {
+                select.searchTerm = 'Vilnius';
+                select.allowDuplicateTag = false;
+                select.isOpen = true;
+                tickAndDetectChanges(fixture);
+                expect(select.showAddTag).toBeFalsy();
+            }));
+
+            it('should allow duplicate tag when term exists among selected items & allowDuplicateTag prop is set as true', fakeAsync(() => {
+                fixture.componentInstance.selectedCities = [{ id: 3, name: 'Pabrade' }];                
+                select.searchTerm = 'Pabrade';
+                select.allowDuplicateTag = true;
+                select.isOpen = true;
+                tickAndDetectChanges(fixture);
+                expect(select.showAddTag).toBeTruthy();
+            }));
         });
     });
 

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -108,6 +108,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() tabIndex: number;
     @Input() readonly = false;
     @Input() keyDownFn = (_: KeyboardEvent) => true;
+    @Input() allowDuplicateTag: true | false = false;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;
@@ -513,8 +514,11 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
 
         term = term.toLowerCase();
         return this.addTag &&
-            (!this.itemsList.filteredItems.some(x => x.label.toLowerCase() === term) &&
-                (!this.hideSelected && this.isOpen || !this.selectedItems.some(x => x.label.toLowerCase() === term))) &&
+            (this.allowDuplicateTag || !this.itemsList.filteredItems.some(x => x.label.toLowerCase() === term) &&
+                (!this.hideSelected && this.isOpen || 
+                    (this.allowDuplicateTag || !this.selectedItems.some(x => x.label.toLowerCase() === term))
+                )
+            ) &&
             !this.loading;
     }
 


### PR DESCRIPTION
This feature helps the user to allow duplicate tags if `allowDuplicateTag` set as true. 
One of the best use cases is, in a company, users might have a same name but with a different id.

This PR closes the #1232 feature request.