### PR TITLE
refactor: always use default search and then custom search if provide…

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -144,9 +144,7 @@ export class ItemsList {
 
         this._filteredItems = [];
         term = this._ngSelect.searchFn ? term : searchHelper.stripSpecialChars(term).toLocaleLowerCase();
-        const match = this._ngSelect.searchFn || this._defaultSearchFn;
         const hideSelected = this._ngSelect.hideSelected;
-
         for (const key of Array.from(this._groups.keys())) {
             const matchedItems = [];
             for (const item of this._groups.get(key)) {
@@ -154,10 +152,19 @@ export class ItemsList {
                     continue;
                 }
                 const searchItem = this._ngSelect.searchFn ? item.value : item;
-                if (match(term, searchItem)) {
+
+                
+                if (this._defaultSearchFn(term, item)) {
                     matchedItems.push(item);
                 }
+                else if(this._ngSelect.searchFn)
+                {
+                    if(this._ngSelect.searchFn(term, item.value)){
+                        matchedItems.push(item);
+                    }
+                }
             }
+            
             if (matchedItems.length > 0) {
                 const [last] = matchedItems.slice(-1);
                 if (last.parent) {


### PR DESCRIPTION
The search functionality change from searching with either the custom search function or the default search function to always using the default search function and then the custom search if provided allows users to use the default search option of searching the label prop of the ngOption object and their own provided search for searching custom fields. 

I was a bit unclear regarding the use case for #692 and the potential updates for extending the search options are fairly open ended between how it can be customized and what should be configurable. If anything, this PR can be used to guide what the expected behavior for this feature should be. 

I look forward to your feedback. 

Thanks much!

#692