### PR TITLE
feat: disabling of keyboard navigation loop

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -290,10 +290,16 @@ export class ItemsList {
     }
 
     private _getNextItemIndex(steps: number) {
-        if (steps > 0) {
-            return (this._markedIndex === this._filteredItems.length - 1) ? 0 : (this._markedIndex + 1);
+        if (this._ngSelect.keyboardSelectLoop === true) {
+            if (steps > 0) {
+                return (this._markedIndex === this._filteredItems.length - 1) ? 0 : (this._markedIndex + 1);
+            }
+            return (this._markedIndex <= 0) ? (this._filteredItems.length - 1) : (this._markedIndex - 1);
+        } else if (steps > 0) {
+            return (this._markedIndex === this._filteredItems.length - 1) ? this._filteredItems.length - 1 : (this._markedIndex + 1);
         }
-        return (this._markedIndex <= 0) ? (this._filteredItems.length - 1) : (this._markedIndex - 1);
+
+        return (this._markedIndex <= 0) ? 0 : (this._markedIndex - 1);
     }
 
     private _stepToItem(steps: number) {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -111,6 +111,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() searchWhileComposing = true;
     @Input() minTermLength = 0;
     @Input() keyDownFn = (_: KeyboardEvent) => true;
+    @Input() keyboardSelectLoop = true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;


### PR DESCRIPTION
Aded feature discussed in https://github.com/ng-select/ng-select/issues/1455 and in https://stackoverflow.com/questions/55834860/prevent-select-field-from-infinite-scrolling-ng-select-angular