### PR TITLE
fix!: Add a notice on CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## Since 3.2.0, notable changes are on [Releases Page](https://github.com/ng-select/ng-select/releases)
+
 ### [3.1.1](https://github.com/ng-select/ng-select/compare/v3.1.0...v3.1.1) (2019-10-19)
 
 ### Features


### PR DESCRIPTION
As it seems that new versions have their changelogs on releases page, I have added a link.