### PR TITLE
fix: null pointer exception in ivy (OnChanges fires before OnInit)

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -73,10 +73,18 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 
     private readonly _destroy$ = new Subject<void>();
     private readonly _dropdown: HTMLElement;
-    private _virtualPadding: HTMLElement;
-    private _scrollablePanel: HTMLElement;
-    private _contentPanel: HTMLElement;
-    private _select: HTMLElement;
+    private get _virtualPadding() {
+        return this.paddingElementRef.nativeElement;
+    };
+    private get _scrollablePanel() {
+        return this.scrollElementRef.nativeElement;
+    };
+    private get _contentPanel() {
+        return this.contentElementRef.nativeElement;
+    };
+    private get _select(): HTMLElement {
+        return this._dropdown.parentElement;
+    };
     private _parent: HTMLElement;
     private _scrollToEndFired = false;
     private _updateScrollHeight = false;
@@ -130,10 +138,6 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     ngOnInit() {
-        this._select = this._dropdown.parentElement;
-        this._virtualPadding = this.paddingElementRef.nativeElement;
-        this._scrollablePanel = this.scrollElementRef.nativeElement;
-        this._contentPanel = this.contentElementRef.nativeElement;
         this._handleScroll();
         this._handleOutsideClick();
         this._appendDropdown();


### PR DESCRIPTION
After update on Angular 9, opening of ng-selects become broken. The error was:
```
Unhandled Promise rejection: Cannot read property 'clientHeight' of undefined ; Zone: <root> ; Task: Promise.then ; Value: TypeError: Cannot read property 'clientHeight' of undefined
    at ng-select.js:2268
```
After a bit of review, you can see that method `_updateItems` become called from `ngOnChanges`, which is called before `ngOnInit`, where is assignment to the undefined variable.

So there is a fix.