### PR TITLE
feat: Click To Clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ map: {
 | clearAllText | `string` | `Clear all` | no | Set custom text for clear all icon title |
 | [clearable] | `boolean` | `true` | no | Allow to clear selected value. Default `true`|
 | [clearOnBackspace] | `boolean` | `true` | no | Clear selected values one by one when clicking backspace. Default `true`|
+| [clearOnClick] | `boolean` | `false` | no | Clear selection when user clicks. Restores selection if nothing is chosen. Cannot be used with **editableSearchTerm** or **multiple**. Does not emit (change) for clearing or restoring. Default `false` |
 | [compareWith] | `(a: any, b: any) => boolean` | `(a, b) => a === b` | no | A function to compare the option values with the selected values. The first argument is a value from an option. The second is a value from the selection(model). A boolean should be returned. |
 | dropdownPosition | `bottom` \| `top` \| `auto` |  `auto` | no | Set the dropdown position on open |
 | [groupBy] | `string` \| `Function` | null | no | Allow to group items by key or function expression |

--- a/src/demo/app/examples/examples.module.ts
+++ b/src/demo/app/examples/examples.module.ts
@@ -46,7 +46,7 @@ import { TemplateOptionExampleComponent } from './template-option-example/templa
 import { TemplateSearchExampleComponent } from './template-search-example/template-search-example.component';
 import { VirtualScrollExampleComponent } from './virtual-scroll-example/virtual-scroll-example.component';
 import { SearchEditableExampleComponent } from './search-editable-example/search-editable-example.component';
-
+import { SearchClearOnClickExampleComponent} from './search-clear-on-click-example/search-clear-on-click-example.component';
 
 const examples = [DataSourceBackendExampleComponent,
     DataSourceArrayExampleComponent,
@@ -91,6 +91,7 @@ const examples = [DataSourceBackendExampleComponent,
     GroupSelectableHiddenExampleComponent,
     GroupChildrenExampleComponent,
     SearchEditableExampleComponent,
+    SearchClearOnClickExampleComponent
 ];
 
 @NgModule({

--- a/src/demo/app/examples/examples.ts
+++ b/src/demo/app/examples/examples.ts
@@ -41,6 +41,7 @@ import { GroupSelectableExampleComponent } from './group-selectable-example/grou
 import { GroupSelectableHiddenExampleComponent } from './group-selectable-hidden-example/group-selectable-hidden-example.component';
 import { GroupChildrenExampleComponent } from './group-children-example/group-children-example.component';
 import { SearchEditableExampleComponent } from './search-editable-example/search-editable-example.component';
+import { SearchClearOnClickExampleComponent } from './search-clear-on-click-example/search-clear-on-click-example.component';
 
 export interface Example {
     component: any;
@@ -95,6 +96,10 @@ export const EXAMPLE_COMPONENTS: { [key: string]: Example } = {
     'search-default-example': {
         component: SearchDefaultExampleComponent,
         title: 'Default search example'
+    },
+    'search-clear-on-click-example': {
+        component: SearchClearOnClickExampleComponent,
+        title: 'Clear on click search example'
     },
     'search-custom-example': {
         component: SearchCustomExampleComponent,

--- a/src/demo/app/examples/search-clear-on-click-example/search-clear-on-click-example.component.html
+++ b/src/demo/app/examples/search-clear-on-click-example/search-clear-on-click-example.component.html
@@ -1,0 +1,13 @@
+<p class="card-text">
+    By default, ng-select does not clear the current value displayed until the user starts typing. You can clear the search value when the user clicks on the component by setting <b>[clearOnClick]</b>
+    input to <b>true</b>. Closing the dropdown without a new selection will restore the previous selection.
+</p>
+
+<ng-select [items]="people$ | async"
+           bindLabel="name"
+           bindValue="id"
+           [clearOnClick]="true"
+           [(ngModel)]="selectedPersonId">
+</ng-select>
+
+<br/>Selected: {{selectedPersonId}}

--- a/src/demo/app/examples/search-clear-on-click-example/search-clear-on-click-example.component.ts
+++ b/src/demo/app/examples/search-clear-on-click-example/search-clear-on-click-example.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { Person, DataService } from '../data.service';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-search-clear-on-click-example',
+  templateUrl: './search-clear-on-click-example.component.html'
+})
+export class SearchClearOnClickExampleComponent implements OnInit {
+
+  people$: Observable<Person[]>;
+  selectedPersonId = '5a15b13c36e7a7f00cf0d7cb';
+
+  constructor(
+    private dataService: DataService) {
+  }
+
+  ngOnInit() {
+    this.people$ = this.dataService.getPeople();
+  }
+
+}

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3834,13 +3834,16 @@ describe('NgSelectComponent', () => {
             expect(select.selectedItems.length).toEqual(0);
         }));
 
-        it('should restore the value and the internal model on outside click, without emitting', fakeAsync(() => {
+        it('should restore the value and the internal model on close, if no selection was made, without emitting', fakeAsync(() => {
             const selectedCity = fixture.componentInstance.cities[0];
             fixture.componentInstance.selectedCity = selectedCity.id;
+            selectOption(fixture, KeyCode.ArrowDown, 0);
             tickAndDetectChanges(fixture);
+            expect(select.selectedItems.length).toEqual(1);
             fixture.componentInstance.select.open();
             tickAndDetectChanges(fixture);
-            document.getElementById('outside').click();
+            expect(select.selectedItems.length).toEqual(0);
+            fixture.componentInstance.select.close();
             tickAndDetectChanges(fixture);
             expect(fixture.componentInstance.selectedCity).toEqual(selectedCity.id);
             expect(select.selectedItems.length).toEqual(1);

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3803,6 +3803,64 @@ describe('NgSelectComponent', () => {
             expectSpyToBeCalledAfterKeyDown(spy, Object.keys(KeyCode).length)
         }))
     })
+
+    describe('Clear on Click', () => {
+        let fixture: ComponentFixture<NgSelectTestCmp>;
+        let select: NgSelectComponent;
+        let input: HTMLInputElement;
+
+        beforeEach(() => {
+            fixture = createTestingModule(
+                NgSelectTestCmp,
+                `<div id="outside"></div><br/>
+                        <ng-select [items]="cities"
+                        [clearOnClick]="true"
+                        bindValue="id"
+                        bindLabel="name"
+                        [(ngModel)]="selectedCity">
+                    </ng-select>`);
+            select = fixture.componentInstance.select;
+            input = select.searchInput.nativeElement;
+        });
+
+        it('should store the value and clear the internal model on open, without emitting', fakeAsync(() => {
+            expect(fixture.componentInstance.select.clearOnClick).toBeTruthy();
+            const selectedCity = fixture.componentInstance.cities[0];
+            fixture.componentInstance.selectedCity = selectedCity.id;
+            tickAndDetectChanges(fixture);
+            input.click();
+            tickAndDetectChanges(fixture);
+            expect(fixture.componentInstance.selectedCity).toEqual(selectedCity.id);
+            expect(select.selectedItems.length).toEqual(0);
+        }));
+
+        it('should restore the value and the internal model on outside click, without emitting', fakeAsync(() => {
+            const selectedCity = fixture.componentInstance.cities[0];
+            fixture.componentInstance.selectedCity = selectedCity.id;
+            tickAndDetectChanges(fixture);
+            input.click();
+            tickAndDetectChanges(fixture);
+            document.getElementById('outside').click();
+            tickAndDetectChanges(fixture);
+            expect(fixture.componentInstance.selectedCity).toEqual(selectedCity.id);
+            expect(select.selectedItems.length).toEqual(1);
+            expect(select.selectedItems[0]).toEqual(selectedCity);
+        }));
+
+        it('should properly update the model when a new selection is made', fakeAsync(() => {
+            const selectedCity = fixture.componentInstance.cities[0];
+            const secondSelectedCity = fixture.componentInstance.cities[1];
+            fixture.componentInstance.selectedCity = selectedCity.id;
+            tickAndDetectChanges(fixture);
+            input.click();
+            tickAndDetectChanges(fixture);
+            selectOption(fixture, KeyCode.ArrowDown, 1);
+            tickAndDetectChanges(fixture);
+            expect(fixture.componentInstance.selectedCity).toEqual(secondSelectedCity.id);
+            expect(select.selectedItems.length).toEqual(1);
+            expect(select.selectedItems[0]).toEqual(secondSelectedCity);
+        }));
+    });
 });
 
 

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3828,7 +3828,7 @@ describe('NgSelectComponent', () => {
             const selectedCity = fixture.componentInstance.cities[0];
             fixture.componentInstance.selectedCity = selectedCity.id;
             tickAndDetectChanges(fixture);
-            input.click();
+            fixture.componentInstance.select.open();
             tickAndDetectChanges(fixture);
             expect(fixture.componentInstance.selectedCity).toEqual(selectedCity.id);
             expect(select.selectedItems.length).toEqual(0);
@@ -3838,13 +3838,13 @@ describe('NgSelectComponent', () => {
             const selectedCity = fixture.componentInstance.cities[0];
             fixture.componentInstance.selectedCity = selectedCity.id;
             tickAndDetectChanges(fixture);
-            input.click();
+            fixture.componentInstance.select.open();
             tickAndDetectChanges(fixture);
             document.getElementById('outside').click();
             tickAndDetectChanges(fixture);
             expect(fixture.componentInstance.selectedCity).toEqual(selectedCity.id);
             expect(select.selectedItems.length).toEqual(1);
-            expect(select.selectedItems[0]).toEqual(selectedCity);
+            expect(select.selectedItems[0].value).toEqual(selectedCity);
         }));
 
         it('should properly update the model when a new selection is made', fakeAsync(() => {
@@ -3852,13 +3852,13 @@ describe('NgSelectComponent', () => {
             const secondSelectedCity = fixture.componentInstance.cities[1];
             fixture.componentInstance.selectedCity = selectedCity.id;
             tickAndDetectChanges(fixture);
-            input.click();
+            fixture.componentInstance.select.open();
             tickAndDetectChanges(fixture);
             selectOption(fixture, KeyCode.ArrowDown, 1);
             tickAndDetectChanges(fixture);
             expect(fixture.componentInstance.selectedCity).toEqual(secondSelectedCity.id);
             expect(select.selectedItems.length).toEqual(1);
-            expect(select.selectedItems[0]).toEqual(secondSelectedCity);
+            expect(select.selectedItems[0].value).toEqual(secondSelectedCity);
         }));
     });
 });


### PR DESCRIPTION
We ran into the same issue as https://github.com/ng-select/ng-select/issues/1467
And my initial workaround was insufficient.

This code adds a feature that works as I believe that issue, and our own use case intend. Comparable to how ui-select could work for AngularJS