### PR TITLE
fix: ngClass overwrites 'ng-select' class

### DIFF
--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -10,6 +10,7 @@ import { NgSelectComponent } from '@ng-select/ng-select';
 import { NgSelectModule } from './ng-select.module';
 import { Subject } from 'rxjs';
 import { NgSelectConfig } from './config.service';
+import { createComponent } from '@angular/compiler/src/core';
 
 describe('NgSelectComponent', () => {
 
@@ -3689,6 +3690,43 @@ describe('NgSelectComponent', () => {
 
             selectOption(fixture, KeyCode.ArrowDown, 0);
             expect(fixture.componentInstance.selectedAccount).toBe('United States');
+        }));
+        it('Should have class ng-select', fakeAsync(()=>{
+            const fixture = createTestingModule(
+                NgSelectGroupingTestCmp,
+                `<ng-select [items]="accounts"
+                        groupBy="country"
+                        bindLabel="name"
+                        bindValue="email"
+                        [(ngModel)]="selectedAccount">
+                </ng-select>`);
+
+                fixture.detectChanges();
+                const element = fixture.elementRef.nativeElement;
+                const elClasses:DOMTokenList = element.children[0].classList;
+                const hasClass = elClasses.contains('ng-select')
+
+            
+            expect(hasClass).toBe(true)
+        }));
+        it('Should have class ng-select and test', fakeAsync(()=>{
+            const fixture = createTestingModule(
+                NgSelectGroupingTestCmp,
+                `<ng-select [items]="accounts"
+                        groupBy="country"
+                        bindLabel="name"
+                        bindValue="email"
+                        [(ngModel)]="selectedAccount"
+                        [class]="'test'">
+                </ng-select>`);
+
+                fixture.detectChanges();
+                const element = fixture.elementRef.nativeElement;
+                const elClasses:DOMTokenList = element.children[0].classList;
+                const hasClass = elClasses.contains('ng-select') && elClasses.contains('test');
+
+            
+            expect(hasClass).toBe(true);
         }));
     });
 

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3691,7 +3691,7 @@ describe('NgSelectComponent', () => {
             selectOption(fixture, KeyCode.ArrowDown, 0);
             expect(fixture.componentInstance.selectedAccount).toBe('United States');
         }));
-        it('Should have class ng-select', fakeAsync(()=>{
+        it('Should have class ng-select', fakeAsync(() => {
             const fixture = createTestingModule(
                 NgSelectGroupingTestCmp,
                 `<ng-select [items]="accounts"
@@ -3703,13 +3703,13 @@ describe('NgSelectComponent', () => {
 
                 fixture.detectChanges();
                 const element = fixture.elementRef.nativeElement;
-                const elClasses:DOMTokenList = element.children[0].classList;
+                const elClasses: DOMTokenList = element.children[0].classList;
                 const hasClass = elClasses.contains('ng-select')
 
             
             expect(hasClass).toBe(true)
         }));
-        it('Should have class ng-select and test', fakeAsync(()=>{
+        it('Should have class ng-select and test', fakeAsync(() => {
             const fixture = createTestingModule(
                 NgSelectGroupingTestCmp,
                 `<ng-select [items]="accounts"
@@ -3722,7 +3722,7 @@ describe('NgSelectComponent', () => {
 
                 fixture.detectChanges();
                 const element = fixture.elementRef.nativeElement;
-                const elClasses:DOMTokenList = element.children[0].classList;
+                const elClasses: DOMTokenList = element.children[0].classList;
                 const hasClass = elClasses.contains('ng-select') && elClasses.contains('test');
 
             

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -186,7 +186,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     element: HTMLElement;
     focused: boolean;
     escapeHTML = true;
-    useDefaultClass:boolean = true;
+    useDefaultClass = true;
 
     private _items = [];
     private _itemsAreUsed: boolean;

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -71,7 +71,7 @@ export type GroupValueFn = (key: string | object, children: any[]) => string | o
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         'role': 'listbox',
-        'class': 'ng-select',
+        '[class.ng-select]': 'useDefaultClass',
         '[class.ng-select-single]': '!multiple',
     }
 })
@@ -186,6 +186,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     element: HTMLElement;
     focused: boolean;
     escapeHTML = true;
+    useDefaultClass:boolean = true;
 
     private _items = [];
     private _itemsAreUsed: boolean;


### PR DESCRIPTION
When you add a dynamic angular class through [class] it overwrites ng-select. Using static classes (class="test") would not create this issue. Related #1535 