### PR TITLE
fix items type for use in strict typescript modes

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -121,11 +121,13 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() @HostBinding('class.ng-select-opened') isOpen = false;
 
     @Input()
-    get items() { return this._items };
+    get items(): any[] | null | undefined { return this._items };
 
-    set items(value: any[]) {
+    set items(value: any[] | null | undefined) {
         this._itemsAreUsed = true;
-        this._items = value;
+        if (value) {
+            this._items = value;
+        }
     };
 
     @Input()


### PR DESCRIPTION
binding to async values gives an error when strict null checks are enabled in the angular template compiler with the typescript options in angular 9:

    "angularCompilerOptions": {
      "fullTemplateTypeCheck": true,
      "strictInjectionParameters": true
    }

https://angular.io/guide/typescript-configuration#typescript-configuration-1