### PR TITLE
chore: remove @angular/localize as peerDependency

### DIFF
--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -21,7 +21,6 @@
   "peerDependencies": {
     "@angular/common": ">=9.0.0 <10.0.0",
     "@angular/core": ">=9.0.0 <10.0.0",
-    "@angular/forms": ">=9.0.0 <10.0.0",
-    "@angular/localize": ">= 9.0.0 <10.0.0"
+    "@angular/forms": ">=9.0.0 <10.0.0"
   }
 }


### PR DESCRIPTION
The ng-select package does not import any modules from @angular/localize.
Should a library user want to use @angular/localize in their project,
the Angular CLI will ensure they are using consistent @angular/* packages
along the way, thus it's not possible for the user to use a version that
is out of range.

closes ng-select#1576