### PR TITLE
fix: search should respect selectable groups if [selectableGroup]="true"

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -166,6 +166,14 @@ export class ItemsList {
                 }
                 this._filteredItems.push(...matchedItems);
             }
+            if (key && this._ngSelect.selectableGroup) {
+                const groupKey = this._ngSelect.groupValue ? this._ngSelect.bindValue : <string>this._ngSelect.groupBy;
+                const optionToCompare = this._items.find(x => x.value[groupKey || <string>groupKey] === key);
+
+                if (!this._filteredItems.includes(optionToCompare) && match(term, optionToCompare)) {
+                    this._filteredItems.push(optionToCompare);
+                }
+            }
         }
     }
 

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2617,6 +2617,25 @@ describe('NgSelectComponent', () => {
             expect(filteredItems[1].label).toBe('Adam');
         }));
 
+        it('should respect selectable groups when filtering if [selectableGroup]="true"', fakeAsync(() => {
+            const fixture = createTestingModule(
+                NgSelectGroupingTestCmp,
+                `<ng-select [items]="accounts"
+                        groupBy="country"
+                        bindLabel="name"
+                        [selectableGroup]="true"
+                        [(ngModel)]="selectedAccount">
+                </ng-select>`);
+
+            tickAndDetectChanges(fixture);
+            fixture.componentInstance.select.filter('United St');
+            tickAndDetectChanges(fixture);
+
+            const filteredItems = fixture.componentInstance.select.itemsList.filteredItems;
+            expect(filteredItems.length).toBe(1);
+            expect(filteredItems[0].label).toBe('United States');
+        }));
+
         it('should continue filtering items on update of items', fakeAsync(() => {
             const fixture = createTestingModule(
                 NgSelectTestCmp,


### PR DESCRIPTION
This fixes #1623 

JFYI, When cloned repo and run test command, I've noticed that one of old tests is failing.
Test name is "should select item with encapsulation = native".