### PR TITLE
fix(compareWith): label is incorrectly used to determine selected item

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ map: {
 | [clearable] | `boolean` | `true` | no | Allow to clear selected value. Default `true`|
 | [clearOnBackspace] | `boolean` | `true` | no | Clear selected values one by one when clicking backspace. Default `true`|
 | [compareWith] | `(a: any, b: any) => boolean` | `(a, b) => a === b` | no | A function to compare the option values with the selected values. The first argument is a value from an option. The second is a value from the selection(model). A boolean should be returned. |
+| [compareWithLabel] | `boolean` | true | no | Whether to preserve legacy functionality of the default compareWith also matching the item label not just the item value.  |
 | dropdownPosition | `bottom` \| `top` \| `auto` |  `auto` | no | Set the dropdown position on open |
 | [groupBy] | `string` \| `Function` | null | no | Allow to group items by key or function expression |
 | [groupValue] |  `(groupKey: string, cildren: any[]) => Object` | - | no | Function expression to provide group value |

--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -97,17 +97,22 @@ export class ItemsList {
         }
     }
 
-    findItem(value: any): NgOption {
-        let findBy: (item: NgOption) => boolean;
+    findItem(value: any): NgOption | undefined {
         if (this._ngSelect.compareWith) {
-            findBy = item => this._ngSelect.compareWith(item.value, value)
+            return this._items.find(item => this._ngSelect.compareWith(item.value, value));
         } else if (this._ngSelect.bindValue) {
-            findBy = item => !item.children && this.resolveNested(item.value, this._ngSelect.bindValue) === value
+            return this._items.find(
+                item => !item.children && this.resolveNested(item.value, this._ngSelect.bindValue) === value);
         } else {
-            findBy = item => item.value === value ||
-                !item.children && item.label && item.label === this.resolveNested(value, this._ngSelect.bindLabel)
+            const option = this._items.find(item => item.value === value);
+
+            if (!this._ngSelect.compareWithLabel) {
+                return option;
+            }
+
+            return option || this._items.find(
+                item => !item.children && item.label && item.label === this.resolveNested(value, this._ngSelect.bindLabel));
         }
-        return this._items.find(item => findBy(item));
     }
 
     addItem(item: any) {

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -1029,6 +1029,66 @@ describe('NgSelectComponent', () => {
                     expect(cmp.select.selectedItems[0].value).toEqual(cmp.cities[1]);
                 }));
 
+                it('should select by label when compareWithLabel is true/unset', fakeAsync(() => {
+                    const fixture = createTestingModule(
+                        NgSelectTestCmp,
+                        `<ng-select
+                            bindLabel="name"
+                            [items]="cities"
+                            [(ngModel)]="selectedCity"
+                            groupBy="state">
+                        </ng-select>`);
+
+                    const cities = [
+                        {id: 1, name: 'Glendale'},
+                        {id: 2, name: 'Pasadena'},
+                    ];
+                    fixture.componentInstance.cities = cities
+                    fixture.componentInstance.selectedCity = {id: -1, name: 'Pasadena'};
+                    tickAndDetectChanges(fixture);
+                    expect(fixture.componentInstance.select.selectedItems[0].value).toEqual(cities[1]);
+                }));
+
+                it('should select by value before label when compareWithLabel is true/unset', fakeAsync(() => {
+                    const fixture = createTestingModule(
+                        NgSelectTestCmp,
+                        `<ng-select
+                            bindLabel="name"
+                            [items]="cities"
+                            [(ngModel)]="selectedCity"
+                            groupBy="state">
+                        </ng-select>`);
+
+                    const glendaleAZ = {id: 1, name: 'Glendale', state: 'Arizona'};
+                    const glendaleCA = {id: 2, name: 'Glendale', state: 'California'};
+                    const cities = [glendaleAZ, glendaleCA];
+                    for (const order of [cities, cities.slice().reverse()]) {
+                        fixture.componentInstance.cities = order
+                        fixture.componentInstance.selectedCity = glendaleCA;
+                        tickAndDetectChanges(fixture);
+                        expect(fixture.componentInstance.select.selectedItems[0].value).toEqual(glendaleCA);
+                    }
+                }));
+
+                it('should select only by value if compareWithLabel is false', fakeAsync(() => {
+                    const fixture = createTestingModule(
+                        NgSelectTestCmp,
+                        `<ng-select
+                            bindLabel="name"
+                            [items]="cities"
+                            [(ngModel)]="selectedCity"
+                            [compareWithLabel]="false">
+                        </ng-select>`);
+
+                    const cities = [
+                        {id: 1, name: 'test'},
+                    ];
+                    fixture.componentInstance.cities = cities
+                    fixture.componentInstance.selectedCity = {id: -1, name: 'test'};
+                    tickAndDetectChanges(fixture);
+                    expect(fixture.componentInstance.select.selectedItems[0].value['id']).toEqual(-1);
+                }));
+
                 it('should select selected when there is no items', fakeAsync(() => {
                     const fixture = createTestingModule(
                         NgSelectTestCmp,

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -78,6 +78,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
 
     @Input() bindLabel: string;
     @Input() bindValue: string;
+    @Input() compareWithLabel = true;
     @Input() markFirst = true;
     @Input() placeholder: string;
     @Input() notFoundText: string;


### PR DESCRIPTION
This PR fixes a regression introduced in d195ccce414985f3128ebf53c697548c3abde43a. The original code searched for
an ``NgOption`` first by identity of its value, but if it could not find a match it then would search by label. The current code defaults to using JavaScript's ``Array.find()`` method to look for a match by identity *and* by label at the same time. Because ``Array.find()`` returns the first match this may yield the incorrect value.

In addition, this PR adds the attribute ``compareWithLabel`` to ``NgSelect`` so that a user can disable this surprising match by label behavior if they wish.