### PR TITLE
fix: scroll to marked item while not searchable

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -744,6 +744,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
                 if (item) {
                     if (this.isOpen) {
                         this.itemsList.markItem(item);
+                        this._scrollToMarked();
                         this._cd.markForCheck();
                     } else {
                         this.select(item);


### PR DESCRIPTION
When using in not searchable mode (dropdown)  you can press keys and ng-select will mark the option that starts from that key, but right now if that option is in scroll, it won't scroll to it. This PR fixes it by adding
```js
this._scrollToMarked();
```

right after
```js
this.itemsList.markItem(item);
```

Before:
![ngGif2](https://user-images.githubusercontent.com/5851280/85740464-51e8f900-b70a-11ea-81a2-eccbf3085cfa.gif)

After:
![ngGif1](https://user-images.githubusercontent.com/5851280/85740252-2403b480-b70a-11ea-8f0d-c9b4e3d6f1b5.gif)

