### PR TITLE
feat: sort search results

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -164,6 +164,7 @@ export class ItemsList {
                     const head = this._items.find(x => x === last.parent);
                     this._filteredItems.push(head);
                 }
+                matchedItems.sort((a, b) => (a.label.toLowerCase().indexOf(term) > b.label.toLowerCase().indexOf(term) ? 1 : -1))
                 this._filteredItems.push(...matchedItems);
             }
         }


### PR DESCRIPTION
Sort search results more relevant.
Results that have search term closer to the start will get higher
Now:
![image](https://user-images.githubusercontent.com/5851280/85738968-1ac61800-b709-11ea-8593-4f19e71a578f.png)

Suggest:
![image](https://user-images.githubusercontent.com/5851280/85739015-23b6e980-b709-11ea-8e58-b19384f8647f.png)

Notice: Groups results will be sorted within the group. 
