### PR TITLE
fix: Explicitly setting the sideEffects property

### DIFF
--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -25,5 +25,6 @@
   },
   "dependencies": {
     "tslib": "^2.0.0"
-  }
+  },
+  "sideEffects": ["*.scss","*.css"]
 }


### PR DESCRIPTION
Fixes #1717

By adding the `sideEffects` property to this project's `package.json`, angular-cli will respect that and copy it over instead of adding `"sideEffects": false` to the generated `package.json` file.

I tested a build and saw this output in the generated `package.json` file:

```
"sideEffects": [
    "*.scss",
    "*.css"
  ],
```