### PR TITLE
fix: simplify append to example

### DIFF
--- a/src/demo/app/examples/append-to-example/append-to-example.component.html
+++ b/src/demo/app/examples/append-to-example/append-to-example.component.html
@@ -28,23 +28,11 @@
 <br>
 <div class="scrollable-box">
     <div class="overflow-box">
-        <div class="wrapper">
-            <ng-select [items]="people | async"
-                    bindLabel="company"
-                    placeholder="Select item"
-                    appendTo=".scrollable-box"
-                    multiple="true"
-                    [closeOnSelect]="false"
-                    [(ngModel)]="selected3">
-            </ng-select>
-            <ng-select [items]="people | async"
-                    bindLabel="company"
-                    placeholder="Select item"
-                    appendTo=".scrollable-box"
-                    multiple="true"
-                    [closeOnSelect]="false"
-                    [(ngModel)]="selected4">
-            </ng-select>
-        </div>
+        <ng-select [items]="people | async"
+                   bindLabel="company"
+                   placeholder="Select item"
+                   appendTo=".scrollable-box"
+                   [(ngModel)]="selected3">
+        </ng-select>
     </div>
 </div>

--- a/src/demo/app/examples/append-to-example/append-to-example.component.scss
+++ b/src/demo/app/examples/append-to-example/append-to-example.component.scss
@@ -13,13 +13,3 @@
     height: 400px;
     overflow: auto;
 }
-
-.wrapper {
-    display:flex;
-    justify-content: space-between;
-    column-gap: 5px;
-}
-
-.wrapper > ng-select {
-    flex: 1 0 auto;
-}

--- a/src/demo/app/examples/append-to-example/append-to-example.component.ts
+++ b/src/demo/app/examples/append-to-example/append-to-example.component.ts
@@ -13,7 +13,6 @@ export class AppendToExampleComponent implements OnInit {
     selected: any;
     selected2: any;
     selected3: any;
-    selected4: any;
 
     constructor(private dataService: DataService) {
     }


### PR DESCRIPTION
Previous example looks bad when we start to make selections.
Now simplified it to just demonstrate appending to a parent div.

Related to #1739