### PR TITLE
fix: make _handleScroll function compatible with ie11

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -216,7 +216,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
                 .pipe(takeUntil(this._destroy$), auditTime(0, SCROLL_SCHEDULER))
                 .subscribe((e: { path, composedPath, target }) => {
                     const path = e.path || (e.composedPath && e.composedPath());
-                    const scrollTop = path.length === 0 ? e.target.scrollTop : path[0].scrollTop
+                    const scrollTop = !path || path.length === 0 ? e.target.scrollTop : path[0].scrollTop
                     this._onContentScrolled(scrollTop);
                 });
         });


### PR DESCRIPTION
On Internet Explorer 11 the `path` is undefined

Closes: #1780