### PR TITLE
fix: "selected" property of values inside groups map with undefined key is not updating correctly when the original property change 

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -365,7 +365,10 @@ export class ItemsList {
             let i = items.length;
             if (key === undefined) {
                 const withoutGroup = groups.get(undefined) || [];
-                items.push(...withoutGroup.map(x => ({ ...x, index: i++ })));
+                items.push(...withoutGroup.map(x => {
+                    x.index = i++;
+                    return x;
+                }));
                 continue;
             }
 

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3829,6 +3829,35 @@ describe('NgSelectComponent', () => {
 
             expect(hasClass).toBe(true);
         }));
+
+        it('should correctly update ng option selected property when groups map has undefined key', fakeAsync(() => {
+            const fixture = createTestingModule(
+              NgSelectGroupingTestCmp,
+              `<ng-select [items]="accounts"
+                        groupBy="group"
+                        bindLabel="name"
+                        bindValue="email"
+                        [(ngModel)]="selectedAccount"
+                        [class]="'test'">
+                </ng-select>`);
+
+            const select = fixture.componentInstance.select;
+            const nativeElement: HTMLElement = fixture.nativeElement as HTMLElement;
+
+            select.filter('Adam');
+            selectOption(fixture, KeyCode.ArrowDown, 0);
+            expect(fixture.componentInstance.selectedAccount).toBe('adam@email.com');
+
+            select.filter('Amalie');
+            selectOption(fixture, KeyCode.ArrowDown, 0);
+            expect(fixture.componentInstance.selectedAccount).toBe('amalie@email.com');
+
+            select.filter('A');
+            expect(nativeElement.querySelectorAll('.ng-option-selected').length).toBe(1, 2);
+            expect(select.viewPortItems.filter((opt => opt.selected)).length).toBe(1, 2);
+            expect(select.viewPortItems.find((opt => opt.selected)).index).toBe(2, 0);
+            expect(select.itemsList.selectedItems.length).toBe(1);
+        }));
     });
 
     describe('Input method composition', () => {


### PR DESCRIPTION
#1628

While filtering, the item received by `this._groups.get(key)`  had the old "selected" property (and maybe all others too) since all of them were not updating after selecting another item

![fix1628](https://user-images.githubusercontent.com/37072694/103783782-70289d80-5039-11eb-83ed-1baaba48c3a4.png)
