### PR TITLE
feat: propagate ngClass value into dropdown panel

### DIFF
--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -70,7 +70,7 @@
 </div>
 
 <ng-dropdown-panel *ngIf="isOpen"
-                   class="ng-dropdown-panel"
+                   [class]="dropdownPanelStaticClasses"
                    [virtualScroll]="virtualScroll"
                    [bufferAmount]="bufferAmount"
                    [appendTo]="appendTo"
@@ -85,7 +85,7 @@
                    (scrollToEnd)="scrollToEnd.emit($event)"
                    (outsideClick)="close()"
                    [class.ng-select-multiple]="multiple"
-                   [ngClass]="appendTo ? classes : null"
+                   [ngClass]="appendTo ? ngClass : null"
                    [id]="dropdownId"
                    role="listbox"
                    aria-label="Options list">

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3576,6 +3576,60 @@ describe('NgSelectComponent', () => {
             });
         }));
 
+        it('should pass static classes into dropdown panel when appendTo is specified', async(() => {
+            const config = new NgSelectConfig();
+            config.appendTo = 'body';
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `
+                <div class="container"></div>
+                <ng-select [items]="cities"
+                        class="someClass"
+                        appendTo=".container"
+                        [(ngModel)]="selectedCity">
+                </ng-select>`,
+                config);
+
+            fixture.componentInstance.select.open();
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => {
+
+                const dropdown = <HTMLElement>document.querySelector('.container .ng-dropdown-panel');
+                expect(dropdown.classList.contains('someClass')).toBe(true);
+            });
+        }));
+
+        it('should pass ngClass classes into dropdown panel when appendTo is specified', async(() => {
+            const config = new NgSelectConfig();
+            config.appendTo = 'body';
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `
+                <div class="container"></div>
+                <ng-select [items]="cities"
+                        [ngClass]="{ someClass: visible }"
+                        appendTo=".container"
+                        [(ngModel)]="selectedCity">
+                </ng-select>`,
+                config);
+
+            fixture.componentInstance.visible = true;
+            fixture.componentInstance.select.open();
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => {
+
+                const dropdown = <HTMLElement>document.querySelector('.container .ng-dropdown-panel');
+                expect(dropdown.classList.contains('someClass')).toBe(true);
+
+                fixture.componentInstance.visible = false;
+                fixture.detectChanges();
+
+                expect(dropdown.classList.contains('someClass')).toBe(false);
+            });
+        }));
+
     });
 
     describe('Grouping', () => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -110,6 +110,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() searchWhileComposing = true;
     @Input() minTermLength = 0;
     @Input() editableSearchTerm = false;
+    @Input() ngClass = null;
     @Input() keyDownFn = (_: KeyboardEvent) => true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
@@ -243,6 +244,13 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             return this.dropdownPanel.currentPosition;
         }
         return undefined;
+    }
+
+    get dropdownPanelStaticClasses() {
+
+        return this.appendTo && this.classes
+            ? `ng-dropdown-panel ${this.classes}`
+            : 'ng-dropdown-panel';
     }
 
     ngOnInit() {


### PR DESCRIPTION
Added an ability to propagate ngClass values into dropdown panel. But please note it is still not possible to propagate [class.*] bindings - I was unable to find a good solution to extract user-specified classes from the full list.

Closes #1627 