### PR TITLE
feat: Allow nullish compareWith

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -131,7 +131,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     get compareWith() { return this._compareWith; }
 
     set compareWith(fn: CompareWithFn) {
-        if (!isFunction(fn)) {
+        if (fn !== undefined && fn !== null && !isFunction(fn)) {
             throw Error('`compareWith` must be a function.');
         }
         this._compareWith = fn;


### PR DESCRIPTION
There are 2 reasons to allow setting compareWith to null/undefined.

1. Reverting the set compareWith - possible the user of the ng-select might want to remove the previously set compareWith to allow default behaviour in combination with bindValue possibly.
2. Extensibility - we have a wrapper around the ng-select that provides custom styles, adds error messages. Not all use cases use compareWith, but some do. Now it is impossible to redirect the [compareWith] @Input without setting the default. That hinders the bindValue default behaviour.