### PR TITLE
fix: add 1 pixel for reliable triggering scrollToEnd

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -368,7 +368,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
             this._virtualPadding :
             this._contentPanel;
 
-        if (scrollTop + this._dropdown.clientHeight >= padding.clientHeight) {
+        if (scrollTop + this._dropdown.clientHeight >= padding.clientHeight - 1) {
             this._zone.run(() => this.scrollToEnd.emit());
             this._scrollToEndFired = true;
         }

--- a/src/ng-select/lib/selection-model.ts
+++ b/src/ng-select/lib/selection-model.ts
@@ -69,12 +69,12 @@ export class DefaultSelectionModel implements SelectionModel {
                 continue;
             }
             child.selected = selected;
-        };
+        }
     }
 
     private _removeChildren(parent: NgOption) {
         this._selected = [
-            ...this._selected.filter(x => x.parent !== parent), 
+            ...this._selected.filter(x => x.parent !== parent),
             ...parent.children.filter(x => x.parent === parent && x.disabled && x.selected)
         ];
     }


### PR DESCRIPTION
It's a weird case, but when you set up page zoom in browser eg 67%, scrollToEnd does not fire because of non-integer pixels:
scrollTop 319.5 + this._dropdown.clientHeight 240 >= padding.clientHieght 560 // false