### PR TITLE
feat: allow items to be null

### DIFF
--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -48,6 +48,17 @@ describe('NgSelectComponent', () => {
                 label: 'No', value: false, disabled: false
             }));
         }));
+
+        it('should create empty items list when initialzied with null', fakeAsync(() => {
+            const fixture = createTestingModule(
+                NgSelectTestCmp,
+                `<ng-select [items]="null">
+                </ng-select>`);
+
+            tickAndDetectChanges(fixture);
+            const itemsList = fixture.componentInstance.select.itemsList;
+            expect(itemsList.items.length).toBe(0);
+        }));
     });
 
     describe('Model bindings and data changes', () => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -122,7 +122,8 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input()
     get items() { return this._items };
 
-    set items(value: any[]) {
+    set items(value: any[] | null) {
+        if (value === null) value = [];
         this._itemsAreUsed = true;
         this._items = value;
     };

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -123,7 +123,9 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     get items() { return this._items };
 
     set items(value: any[] | null) {
-        if (value === null) value = [];
+        if (value === null) {
+            value = [];
+        }
         this._itemsAreUsed = true;
         this._items = value;
     };


### PR DESCRIPTION
When using the async pipe and angulars strict template checking this will no longer throw.
fixes Ref#1580
fixes Ref#1581