### PR TITLE
perf: reduce change detection cycles  by listening the `mousedown` in the root zone

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -4,7 +4,6 @@ import {
     Component,
     ElementRef,
     EventEmitter,
-    HostListener,
     Inject,
     Input,
     NgZone,
@@ -120,15 +119,6 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
         return 0;
     }
 
-    @HostListener('mousedown', ['$event'])
-    handleMousedown($event: MouseEvent) {
-        const target = $event.target as HTMLElement;
-        if (target.tagName === 'INPUT') {
-            return;
-        }
-        $event.preventDefault();
-    }
-
     ngOnInit() {
         this._select = this._dropdown.parentElement;
         this._virtualPadding = this.paddingElementRef.nativeElement;
@@ -137,6 +127,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
         this._handleScroll();
         this._handleOutsideClick();
         this._appendDropdown();
+        this._setupMousedownListener();
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -427,5 +418,19 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
             this._dropdown.style.top = offsetTop + delta + 'px';
             this._dropdown.style.bottom = 'auto';
         }
+    }
+
+    private _setupMousedownListener(): void {
+        this._zone.runOutsideAngular(() => {
+            fromEvent(this._dropdown, 'mousedown')
+                .pipe(takeUntil(this._destroy$))
+                .subscribe((event: MouseEvent) => {
+                    const target = event.target as HTMLElement;
+                    if (target.tagName === 'INPUT') {
+                        return;
+                    }
+                    event.preventDefault();
+                });
+        });
     }
 }


### PR DESCRIPTION
This PR reduces change detection cycles for the `ng-dropdown-panel` by replacing
`HostListener` with `fromEvent` outside of the zone. Calling `preventDefault()`
on the event doesn't require Angular to run `ApplicationRef.tick()`. Note that the
`HostListener` wraps the actual listener under the hood into the internal Angular function
which runs `markDirty()` before running the actual listener (the decorated class method).

![image](https://user-images.githubusercontent.com/7337691/124315425-9492ac00-db7c-11eb-92ee-adb21f09f745.png)
