### PR TITLE
Only auto select dropdown position 'top' when there is room for it.

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -374,7 +374,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
         const offsetTop = selectRect.top + window.pageYOffset;
         const height = selectRect.height;
         const dropdownHeight = dropdownEl.getBoundingClientRect().height;
-        if (offsetTop + height + dropdownHeight > scrollTop + document.documentElement.clientHeight) {
+        if (offsetTop + height + dropdownHeight > scrollTop + document.documentElement.clientHeight && offsetTop - dropdownHeight > 0) {
             return 'top';
         } else {
             return 'bottom';


### PR DESCRIPTION
Prefer 'bottom' when there is no room for the dropdown (top or bottom) because then you would at least get a scroll bar.

Issue reproduction: 
 - Open https://ng-select.github.io/ng-select#/virtual-scroll
 - Open ng-select dropdown.
 - Decrease height of browser window until lower part of dropdown disappears.
 - Close dropdown
 - Open dropdown again.

Now the dropdown drops "up" but the top portion is not visible (The part with "Loading 50 of 5000").

This pull request add a check that there is room for the dropdown before choosing 'top'