### PR TITLE
fix: search term doesn't return matching items

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -566,7 +566,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             return;
         }
 
-        this.searchTerm = term;
+        this.searchTerm = term.trim();
         if (this._isTypeahead && (this._validTerm || this.minTermLength === 0)) {
             this.typeahead.next(term);
         }


### PR DESCRIPTION

Trim the search query input before searching in the items list.

The search query input need to have no white spaces.