### PR TITLE
fix: a11y improvements for ng-dropdown-panel

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -38,7 +38,7 @@ const SCROLL_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? animatio
         <div *ngIf="headerTemplate" class="ng-dropdown-header">
             <ng-container [ngTemplateOutlet]="headerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>
         </div>
-        <div #scroll class="ng-dropdown-panel-items scroll-host">
+        <div #scroll role="listbox" class="ng-dropdown-panel-items scroll-host">
             <div #padding [class.total-padding]="virtualScroll"></div>
             <div #content [class.scrollable-content]="virtualScroll && items.length">
                 <ng-content></ng-content>


### PR DESCRIPTION
Changes to "ng-dropdown-panel" for better accessibility as the "American Disability Act" becomes mainstream and other developers may or may not have to comply with it as well in the future.

Tested with VoiceOver on Android 11, change is made so that a screen reader i.e. NVDA, Talkback, or Voiceover would speak the number of items present in a list.