### PR TITLE
feat: add clearSearchOnAdd to NgSelectConfig

### DIFF
--- a/src/ng-select/lib/config.service.ts
+++ b/src/ng-select/lib/config.service.ts
@@ -14,4 +14,5 @@ export class NgSelectConfig {
     bindValue: string;
     bindLabel: string;
     appearance = 'underline';
+    clearSearchOnAdd: boolean;
 }

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2979,6 +2979,57 @@ describe('NgSelectComponent', () => {
                 fixture.componentInstance.select.select(fixture.componentInstance.select.viewPortItems[0]);
                 expect(lastEmittedSearchTerm).toBe(null);
             }));
+
+            it('should respect NgSelectConfig.clearSearchOnAdd if defined', fakeAsync(() => {
+                const config = new NgSelectConfig();
+                config.clearSearchOnAdd = true;
+                const fixture = createTestingModule(
+                    NgSelectTestCmp,
+                    `<ng-select [items]="cities"
+                        [typeahead]="filter"
+                        bindLabel="name"
+                        [hideSelected]="hideSelected"
+                        [closeOnSelect]="false"
+                        [(ngModel)]="selectedCity">
+                    </ng-select>`, config);
+
+                expect(fixture.componentInstance.select.clearSearchOnAdd).toBeTruthy();
+
+                fixture.componentInstance.filter.subscribe();
+                fixture.componentInstance.select.filter('new');
+                fixture.componentInstance.cities = [{ id: 4, name: 'New York' }];
+                tickAndDetectChanges(fixture);
+
+                fixture.componentInstance.select.select(fixture.componentInstance.select.viewPortItems[0]);
+                expect(fixture.componentInstance.select.itemsList.filteredItems.length).toBe(1);
+                expect(fixture.componentInstance.select.searchTerm).toBe(null);
+            }));
+
+            it('should allow user to override NgSelectConfig.clearSearchOnAdd on a per component basis', fakeAsync(() => {
+                const config = new NgSelectConfig();
+                config.clearSearchOnAdd = true;
+                const fixture = createTestingModule(
+                    NgSelectTestCmp,
+                    `<ng-select [items]="cities"
+                        [typeahead]="filter"
+                        bindLabel="name"
+                        [hideSelected]="hideSelected"
+                        [closeOnSelect]="false"
+                        [clearSearchOnAdd]="false"
+                        [(ngModel)]="selectedCity">
+                    </ng-select>`, config);
+
+                expect(fixture.componentInstance.select.clearSearchOnAdd).toBeFalsy();
+
+                fixture.componentInstance.filter.subscribe();
+                fixture.componentInstance.select.filter('new');
+                fixture.componentInstance.cities = [{ id: 4, name: 'New York' }];
+                tickAndDetectChanges(fixture);
+
+                fixture.componentInstance.select.select(fixture.componentInstance.select.viewPortItems[0]);
+                expect(fixture.componentInstance.select.itemsList.filteredItems.length).toBe(1);
+                expect(fixture.componentInstance.select.searchTerm).toBe('new');
+            }));
         });
 
         describe('edit search query', () => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -141,7 +141,14 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     @Input()
-    get clearSearchOnAdd() { return isDefined(this._clearSearchOnAdd) ? this._clearSearchOnAdd : this.closeOnSelect; };
+    get clearSearchOnAdd() {
+        if (isDefined(this._clearSearchOnAdd)) {
+            return this._clearSearchOnAdd;
+        } else if (isDefined(this.config.clearSearchOnAdd)) {
+            return this.config.clearSearchOnAdd;
+        }
+        return this.closeOnSelect;
+    };
 
     set clearSearchOnAdd(value) {
         this._clearSearchOnAdd = value;
@@ -218,7 +225,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     constructor(
         @Attribute('class') public classes: string,
         @Attribute('autofocus') private autoFocus: any,
-        config: NgSelectConfig,
+        public config: NgSelectConfig,
         @Inject(SELECTION_MODEL_FACTORY) newSelectionModel: SelectionModelFactory,
         _elementRef: ElementRef<HTMLElement>,
         private _cd: ChangeDetectorRef,


### PR DESCRIPTION
This PR adds a way to define a default `clearSearchOnAdd` in NgSelectConfig as described in #1973 , but can be override if user define `[clearSearchOnAdd]` on the component.