### PR TITLE
feat: ignore ctrl+enter like a normal select

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -313,7 +313,9 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
                 this._handleSpace($event);
                 break;
             case KeyCode.Enter:
-                this._handleEnter($event);
+	        if (!$event.ctrlKey) {
+                    this._handleEnter($event);
+	        }
                 break;
             case KeyCode.Tab:
                 this._handleTab($event);


### PR DESCRIPTION
The rationale of this change is as follows:

Having an input text focused, one can submit a form by pressing enter.
But this does not work when other elements like textarea and select are
in focus.

To circumvent this, one can define ctrl+enter to submit a form,
regardless which element is in focus.

Prior to this change, when pressing ctrl+enter, the user would see the
ng-select menu reopen whilst submitting which is confusing.

By ignoring the control key press, ng-select does not reopen and behaves
like a standard select.