### PR TITLE
feat: add 'left' and 'right' options to dropdownPosition

### DIFF
--- a/src/demo/app/examples/dropdown-position-example/dropdown-position-example.component.html
+++ b/src/demo/app/examples/dropdown-position-example/dropdown-position-example.component.html
@@ -8,10 +8,22 @@
 
 <hr>
 <p>
-    You can force position to bottom or top by setting <b>dropdownPosition</b>
+    You can force position to top, right, bottom, or left by setting <b>dropdownPosition</b>.
 </p>
 
 <ng-select [dropdownPosition]="'top'"
+           [searchable]="false"
+           [items]="cities">
+</ng-select>
+
+<hr>
+<ng-select [dropdownPosition]="'right'"
+           [searchable]="false"
+           [items]="cities">
+</ng-select>
+
+<hr>
+<ng-select [dropdownPosition]="'left'"
            [searchable]="false"
            [items]="cities">
 </ng-select>

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -181,7 +181,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 
     private _handleDropdownPosition() {
         this._currentPosition = this._calculateCurrentPosition(this._dropdown);
-        if(CSS_POSITIONS.includes(this._currentPosition)) {
+        if (CSS_POSITIONS.includes(this._currentPosition)) {
             this._updateDropdownClass(this._currentPosition);
         } else {
             this._updateDropdownClass('bottom');
@@ -197,14 +197,14 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 
     private _updateDropdownClass(currentPosition: string) {
         CSS_POSITIONS.forEach((position) => {
-            const CSS_CLASS = `ng-select-${position}`;
-            this._renderer.removeClass(this._dropdown, CSS_CLASS);
-            this._renderer.removeClass(this._select, CSS_CLASS);
+            const REMOVE_CSS_CLASS = `ng-select-${position}`;
+            this._renderer.removeClass(this._dropdown, REMOVE_CSS_CLASS);
+            this._renderer.removeClass(this._select, REMOVE_CSS_CLASS);
         });
 
-        const CSS_CLASS = `ng-select-${currentPosition}`;
-        this._renderer.addClass(this._dropdown, CSS_CLASS);
-        this._renderer.addClass(this._select, CSS_CLASS);
+        const ADD_CSS_CLASS = `ng-select-${currentPosition}`;
+        this._renderer.addClass(this._dropdown, ADD_CSS_CLASS);
+        this._renderer.addClass(this._select, ADD_CSS_CLASS);
     }
 
     private _handleScroll() {

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -26,8 +26,7 @@ import { DropdownPosition } from './ng-select.component';
 import { NgOption } from './ng-select.types';
 import { isDefined } from './value-utils';
 
-const TOP_CSS_CLASS = 'ng-select-top';
-const BOTTOM_CSS_CLASS = 'ng-select-bottom';
+const CSS_POSITIONS: Readonly<string[]> = ['top', 'right', 'bottom', 'left'];
 const SCROLL_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? animationFrameScheduler : asapScheduler;
 
 @Component({
@@ -182,23 +181,30 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 
     private _handleDropdownPosition() {
         this._currentPosition = this._calculateCurrentPosition(this._dropdown);
-        if (this._currentPosition === 'top') {
-            this._renderer.addClass(this._dropdown, TOP_CSS_CLASS);
-            this._renderer.removeClass(this._dropdown, BOTTOM_CSS_CLASS);
-            this._renderer.addClass(this._select, TOP_CSS_CLASS);
-            this._renderer.removeClass(this._select, BOTTOM_CSS_CLASS)
+        if(CSS_POSITIONS.includes(this._currentPosition)) {
+            this._updateDropdownClass(this._currentPosition);
         } else {
-            this._renderer.addClass(this._dropdown, BOTTOM_CSS_CLASS);
-            this._renderer.removeClass(this._dropdown, TOP_CSS_CLASS);
-            this._renderer.addClass(this._select, BOTTOM_CSS_CLASS);
-            this._renderer.removeClass(this._select, TOP_CSS_CLASS);
+            this._updateDropdownClass('bottom');
         }
+        
 
         if (this.appendTo) {
             this._updateYPosition();
         }
 
         this._dropdown.style.opacity = '1';
+    }
+
+    private _updateDropdownClass(currentPosition: string) {
+        CSS_POSITIONS.forEach((position) => {
+            const CSS_CLASS = `ng-select-${position}`;
+            this._renderer.removeClass(this._dropdown, CSS_CLASS);
+            this._renderer.removeClass(this._select, CSS_CLASS);
+        });
+
+        const CSS_CLASS = `ng-select-${currentPosition}`;
+        this._renderer.addClass(this._dropdown, CSS_CLASS);
+        this._renderer.addClass(this._select, CSS_CLASS);
     }
 
     private _handleScroll() {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -53,7 +53,7 @@ import { NgSelectConfig } from './config.service';
 import { NgDropdownPanelService } from './ng-dropdown-panel.service';
 
 export const SELECTION_MODEL_FACTORY = new InjectionToken<SelectionModelFactory>('ng-select-selection-model');
-export type DropdownPosition = 'bottom' | 'top' | 'auto';
+export type DropdownPosition = 'top' | 'right' | 'bottom' | 'left' | 'auto';
 export type AddTagFn = ((term: string) => any | Promise<any>);
 export type CompareWithFn = (a: any, b: any) => boolean;
 export type GroupValueFn = (key: string | object, children: any[]) => string | object;

--- a/src/ng-select/themes/ant.design.theme.scss
+++ b/src/ng-select/themes/ant.design.theme.scss
@@ -247,13 +247,26 @@ $ng-select-marked: #e6f7ff !default;
     margin-top: 4px;
     margin-bottom: 4px;
     left: 0;
+    &.ng-select-top {
+        bottom: 100%;
+        border-bottom-color: lighten($ng-select-border, 10);
+    }
+    &.ng-select-right {
+        left: 100%;
+        top: 0;
+        border-bottom-color: lighten($ng-select-border, 10);
+        margin-top: 0;
+        margin-left: 4px;
+    }
     &.ng-select-bottom {
         top: 100%;
         border-top-color: lighten($ng-select-border, 10);
     }
-    &.ng-select-top {
-        bottom: 100%;
+    &.ng-select-left {
+        left: calc(-100% - 4px);
+        top: 0;
         border-bottom-color: lighten($ng-select-border, 10);
+        margin-top: 0;
     }
     .ng-dropdown-header {
         border-bottom: 1px solid $ng-select-border;

--- a/src/ng-select/themes/default.theme.scss
+++ b/src/ng-select/themes/default.theme.scss
@@ -42,16 +42,28 @@ $ng-select-input-text: #000000 !default;
                 }
             }
         }
+        &.ng-select-top {
+            > .ng-select-container {
+                border-top-right-radius: 0;
+                border-top-left-radius: 0;
+            }
+        }
+        &.ng-select-right {
+            > .ng-select-container {
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
+            }
+        }
         &.ng-select-bottom {
             > .ng-select-container {
                 border-bottom-right-radius: 0;
                 border-bottom-left-radius: 0;
             }
         }
-        &.ng-select-top {
+        &.ng-select-left {
             > .ng-select-container {
-                border-top-right-radius: 0;
                 border-top-left-radius: 0;
+                border-bottom-left-radius: 0;
             }
         }
     }
@@ -232,6 +244,37 @@ $ng-select-input-text: #000000 !default;
     border: 1px solid $ng-select-border;
     box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
     left: 0;
+    &.ng-select-top {
+        bottom: 100%;
+        border-top-right-radius: 4px;
+        border-top-left-radius: 4px;
+        border-bottom-color: lighten($ng-select-border, 10);
+        margin-bottom: -1px;
+        .ng-dropdown-panel-items {
+            .ng-option {
+                &:first-child {
+                    border-top-right-radius: 4px;
+                    border-top-left-radius: 4px;
+                }
+            }
+        }
+    }
+    &.ng-select-right {
+        left: 100%;
+        top: 0;
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-bottom-left-radius: 4px;
+        border-bottom-color: lighten($ng-select-border, 10);
+        margin-bottom: -1px;
+        .ng-dropdown-panel-items {
+            .ng-option {
+                &:first-child {
+                    border-top-right-radius: 4px;
+                }
+            }
+        }
+    }
     &.ng-select-bottom {
         top: 100%;
         border-bottom-right-radius: 4px;
@@ -247,16 +290,17 @@ $ng-select-input-text: #000000 !default;
             }
         }
     }
-    &.ng-select-top {
-        bottom: 100%;
-        border-top-right-radius: 4px;
+    &.ng-select-left {
+        left: -100%;
+        top: 0;
         border-top-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-bottom-left-radius: 4px;
         border-bottom-color: lighten($ng-select-border, 10);
         margin-bottom: -1px;
         .ng-dropdown-panel-items {
             .ng-option {
                 &:first-child {
-                    border-top-right-radius: 4px;
                     border-top-left-radius: 4px;
                 }
             }

--- a/src/ng-select/themes/material.theme.scss
+++ b/src/ng-select/themes/material.theme.scss
@@ -241,12 +241,23 @@ $ng-select-bg: #ffffff !default;
 .ng-dropdown-panel {
     background: $ng-select-bg;
     left: 0;
+    &.ng-select-top {
+        bottom: calc(100% - .84375em);
+        box-shadow: 0 -5px 5px -3px rgba(0, 0, 0, .2), 0 -8px 10px 1px rgba(0, 0, 0, .14), 0 -3px 14px 2px $ng-select-divider;
+    }
+    &.ng-select-right {
+        left: 100%;
+        top: calc(0% + .84375em);
+        box-shadow: 0 -5px 5px -3px rgba(0, 0, 0, .2), 0 -8px 10px 1px rgba(0, 0, 0, .14), 0 -3px 14px 2px $ng-select-divider;
+        margin-left: 4px;
+    }
     &.ng-select-bottom {
         top: calc(100% - 1.25em);
         box-shadow: 0 5px 5px -3px rgba(0, 0, 0, .2), 0 8px 10px 1px rgba(0, 0, 0, .14), 0 3px 14px 2px $ng-select-divider;
     }
-    &.ng-select-top {
-        bottom: calc(100% - .84375em);
+    &.ng-select-left {
+        left: calc(-100% - 4px);
+        top: calc(0% + .84375em);
         box-shadow: 0 -5px 5px -3px rgba(0, 0, 0, .2), 0 -8px 10px 1px rgba(0, 0, 0, .14), 0 -3px 14px 2px $ng-select-divider;
     }
     &.multiple {


### PR DESCRIPTION
Adds the ability to set `dropdownPosition` to `'left'` or `'right'` as described in #1060.

## Notes
- The position `'auto'` can still only set the `dropdownPosition` to `'top'` or `'bottom'`.  
I am not sure how to automatically determine whether to use `'left'` or `'right'` or whether it is a good idea.
- Appropriate styling has been added for all three themes.
- Additional examples have been added to the demo's dropdown-position page.