### PR TITLE
chore: update deprecated build --prod flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "build": "ng build ng-select && ng build ng-option-highlight && yarn build:themes && yarn copy-sass",
-    "build:demo": "ng build demo --prod --baseHref=/ng-select && yarn copy-examples",
+    "build:demo": "ng build demo --configuration production --baseHref=/ng-select && yarn copy-examples",
     "build:themes": "node-sass --output-style compressed src/ng-select/themes/ -o dist/ng-select/themes",
     "copy-sass": "mkdir -p dist/ng-select/scss && cp src/ng-select/**/*.scss dist/ng-select/scss",
     "copy-examples": "cp -r src/demo/app/examples dist/demo",


### PR DESCRIPTION
Angular build flag `--prod` is deprecated. Updates package.json to use `--configuration production` instead.