### PR TITLE
fix: fix scss files not being exported for Angular 13

### DIFF
--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -18,6 +18,17 @@
     "autocomplete",
     "angular2"
   ],
+  "exports": {
+    "./scss/ant.design.theme": {
+      "style": "./scss/ant.design.theme.scss"
+    },
+    "./scss/default.theme": {
+      "style": "./scss/default.theme.scss"
+    },
+    "./scss/material.theme": {
+      "style": "./scss/material.theme.scss"
+    }
+  },
   "peerDependencies": {
     "@angular/common": ">=13.0.0 <14.0.0",
     "@angular/core": ">=13.0.0 <14.0.0",


### PR DESCRIPTION
This fixes an issue with v8.x that was missed in #1996 

See: https://angular.io/guide/creating-libraries#managing-assets-in-a-library