### PR TITLE
feat: allow items to be undefined

### DIFF
--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -59,6 +59,17 @@ describe('NgSelectComponent', () => {
             const itemsList = fixture.componentInstance.select.itemsList;
             expect(itemsList.items.length).toBe(0);
         }));
+
+        it('should create empty items list when initialzied with undefined', fakeAsync(() => {
+            const fixture = createTestingModule(
+                NgSelectTestComponent,
+                `<ng-select [items]="undefined">
+                </ng-select>`);
+
+            tickAndDetectChanges(fixture);
+            const itemsList = fixture.componentInstance.select.itemsList;
+            expect(itemsList.items.length).toBe(0);
+        }));
     });
 
     describe('Model bindings and data changes', () => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -118,8 +118,8 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     @Input()
     get items() { return this._items };
 
-    set items(value: any[] | null) {
-        if (value === null) {
+    set items(value: any[] | null | undefined) {
+        if (value === null || value === undefined) {
             value = [];
         }
         this._itemsAreUsed = true;


### PR DESCRIPTION
When using the ngrxPush pipe and angulars strict template checking this will no longer throw.

Angular's async pipe and ngrxPush have different default values:

    async: default null (transform<T>(obs: Observable<T>): T | null)
    ngrxPush: default undefined (transform<T>(obs: Observable<T>): T | undefined)