### PR TITLE
WIP: Allow option with null value

### DIFF
--- a/src/demo/app/examples/examples.module.ts
+++ b/src/demo/app/examples/examples.module.ts
@@ -15,6 +15,9 @@ import { FormsAsyncDataExampleComponent } from './forms-async-data-example/forms
 import { FormsCustomTemplateExampleComponent } from './forms-custom-template-example/forms-custom-template-example.component';
 import { FormsMultiSelectExampleComponent } from './forms-multi-select-example/forms-multi-select-example.component';
 import { FormsSingleSelectExampleComponent } from './forms-single-select-example/forms-single-select-example.component';
+import {
+    FormsSingleSelectOptionNullExampleComponent
+} from './forms-single-select-option-null-example/forms-single-select-option-null-example.component';
 import { FormsWithOptionsExampleComponent } from './forms-with-options-example/forms-with-options-example.component';
 import { GroupChildrenExampleComponent } from './group-children-example/group-children-example.component';
 import { GroupDefaultExampleComponent } from './group-default-example/group-default-example.component';
@@ -53,6 +56,7 @@ const examples = [DataSourceBackendExampleComponent,
     DataSourceOptionsExampleComponent,
     FormsWithOptionsExampleComponent,
     FormsSingleSelectExampleComponent,
+    FormsSingleSelectOptionNullExampleComponent,
     FormsMultiSelectExampleComponent,
     FormsAsyncDataExampleComponent,
     FormsCustomTemplateExampleComponent,

--- a/src/demo/app/examples/examples.ts
+++ b/src/demo/app/examples/examples.ts
@@ -1,6 +1,9 @@
 import { DataSourceBackendExampleComponent } from './data-source-backend-example/data-source-backend-example.component';
 import { DataSourceArrayExampleComponent } from './data-source-array-example/data-source-array-example.component';
 import { DataSourceOptionsExampleComponent } from './data-source-options-example/data-source-options-example.component';
+import {
+    FormsSingleSelectOptionNullExampleComponent
+} from './forms-single-select-option-null-example/forms-single-select-option-null-example.component';
 import { FormsWithOptionsExampleComponent } from './forms-with-options-example/forms-with-options-example.component';
 import { FormsSingleSelectExampleComponent } from './forms-single-select-example/forms-single-select-example.component';
 import { FormsMultiSelectExampleComponent } from './forms-multi-select-example/forms-multi-select-example.component';
@@ -67,6 +70,10 @@ export const EXAMPLE_COMPONENTS: { [key: string]: Example } = {
     'forms-single-select-example': {
         component: FormsSingleSelectExampleComponent,
         title: 'Single select with required validation'
+    },
+    'null-single-select-example-option-null': {
+        component: FormsSingleSelectOptionNullExampleComponent,
+        title: 'Single select with option null'
     },
     'forms-multi-select-example': {
         component: FormsMultiSelectExampleComponent,

--- a/src/demo/app/examples/forms-single-select-option-null-example/forms-single-select-option-null-example.component.html
+++ b/src/demo/app/examples/forms-single-select-option-null-example/forms-single-select-option-null-example.component.html
@@ -1,0 +1,73 @@
+<form [formGroup]="heroForm1" novalidate>
+
+    <div class="form-group">
+        <label for="age1">Age</label>
+        <ng-select [selectOnTab]="true"
+                   labelForId="age1"
+                   placeholder="Select age"
+                   formControlName="age"
+                   [multiple]="false"
+                   bindLabel="label"
+                   bindValue="value"
+                   [items]="ages"
+                   [allowNullValue]="true"
+        >
+        </ng-select>
+    </div>
+
+</form>
+
+<form [formGroup]="heroForm2" novalidate>
+
+    <div class="form-group">
+        <label for="age2">Age</label>
+        <ng-select [selectOnTab]="true"
+                   labelForId="age2"
+                   placeholder="Select age"
+                   formControlName="age"
+                   [multiple]="false"
+                   [allowNullValue]="true"
+        >
+            <ng-option *ngFor="let age of ages" [value]="age.value">{{ age.label }}</ng-option>
+        </ng-select>
+    </div>
+
+</form>
+
+<form [formGroup]="heroForm3" novalidate>
+
+    <div class="form-group">
+        <label for="age3">Age</label>
+        <ng-select [selectOnTab]="true"
+                   labelForId="age3"
+                   placeholder="Select age"
+                   formControlName="age"
+                   [multiple]="true"
+                   bindLabel="label"
+                   bindValue="value"
+                   [items]="ages"
+                   [allowNullValue]="true"
+        >
+        </ng-select>
+    </div>
+
+</form>
+
+<form [formGroup]="heroForm4" novalidate>
+
+    <div class="form-group">
+        <label for="age4">Age</label>
+        <ng-select [selectOnTab]="true"
+                   labelForId="age4"
+                   placeholder="Select age"
+                   formControlName="age"
+                   [multiple]="true"
+                   [allowNullValue]="true"
+        >
+            <ng-option *ngFor="let age of ages"
+                       [value]="age.value">{{ age.label }}</ng-option>
+        </ng-select>
+    </div>
+
+</form>
+

--- a/src/demo/app/examples/forms-single-select-option-null-example/forms-single-select-option-null-example.component.ts
+++ b/src/demo/app/examples/forms-single-select-option-null-example/forms-single-select-option-null-example.component.ts
@@ -1,0 +1,58 @@
+import { Component } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'forms-single-select-option-null-example',
+  templateUrl: './forms-single-select-option-null-example.component.html',
+  styleUrls: ['./forms-single-select-option-null-example.component.scss'],
+})
+export class FormsSingleSelectOptionNullExampleComponent {
+
+  heroForm1 = this.fb.group({
+    age: ['', Validators.required],
+  });
+  heroForm2 = this.fb.group({
+    age: ['', Validators.required],
+  });
+  heroForm3 = this.fb.group({
+    age: [[''], Validators.required],
+  });
+  heroForm4 = this.fb.group({
+    age: [[''], Validators.required],
+  });
+
+  ages: any[] = [
+    // { value: null, label: 'All' },
+    { value: '<18', label: 'Under 18' },
+    { value: '18', label: '18' },
+    { value: '>18', label: 'More than 18' },
+  ];
+
+  agesWithoutNull: any[] = [
+    { value: '<18', label: 'Under 18' },
+    { value: '18', label: '18' },
+    { value: '>18', label: 'More than 18' },
+  ];
+
+  constructor(private fb: FormBuilder) {}
+
+  ngAfterViewInit(): void {
+    setTimeout(() => {
+      this.heroForm1.controls.age.setValue(null);
+      this.heroForm2.controls.age.setValue(null);
+      this.heroForm3.controls.age.setValue([null]);
+      this.heroForm4.controls.age.setValue([null]);
+      // this.ages.push({ value: null, label: 'All' });
+      // this.ages = [...this.ages];
+
+      setTimeout(() => {
+        this.ages = [
+          { value: null, label: 'All' },
+          { value: '<18', label: 'Under 18' },
+          { value: '18', label: '18' },
+          { value: '>18', label: 'More than 18' },
+        ];
+      }, 3000);
+    }, 3000);
+  }
+}

--- a/src/demo/app/routes.ts
+++ b/src/demo/app/routes.ts
@@ -36,4 +36,5 @@ export const appRoutes: Routes = [
         data: { title: 'Append to element', examples: 'append-to' }
     },
     { path: 'grouping', component: RouteViewerComponent, data: { title: 'Grouping', examples: 'group' } },
+    { path: 'null', component: RouteViewerComponent, data: { title: 'Null', examples: 'null' } },
 ];

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -4195,7 +4195,7 @@ class NgSelectTestComponent {
     }
 
     compareWith(a, b) {
-        return a.name === b.name && a.district === b.district
+        return a?.name === b?.name && a?.district === b?.district
     }
 
     toggleVisible() {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -106,6 +106,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     @Input() searchWhileComposing = true;
     @Input() minTermLength = 0;
     @Input() editableSearchTerm = false;
+    @Input() allowNullValue = false;
     @Input() keyDownFn = (_: KeyboardEvent) => true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
@@ -684,7 +685,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     }
 
     private _isValidWriteValue(value: any): boolean {
-        if (!isDefined(value) || (this.multiple && value === '') || Array.isArray(value) && value.length === 0) {
+        if (!isDefined(value, this.allowNullValue) || (this.multiple && value === '') || Array.isArray(value) && value.length === 0) {
             return false;
         }
 
@@ -719,6 +720,10 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             if (item) {
                 this.itemsList.select(item);
             } else {
+                if (!this.allowNullValue && val === null) {
+                    return;
+                }
+
                 const isValObject = isObject(val);
                 const isPrimitive = !isValObject && !this.bindValue;
                 if ((isValObject || isPrimitive)) {
@@ -803,7 +808,15 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             this._onChange(model);
             this.changeEvent.emit(selected);
         } else {
-            this._onChange(isDefined(model[0]) ? model[0] : null);
+            let value = isDefined(model[0], this.allowNullValue)
+              ? model[0]
+              : (this.allowNullValue ? undefined : null);
+
+            if (value?.$ngOptionValue === null) {
+                value = null;
+            }
+
+            this._onChange(value);
             this.changeEvent.emit(selected[0]);
         }
 

--- a/src/ng-select/lib/value-utils.ts
+++ b/src/ng-select/lib/value-utils.ts
@@ -14,7 +14,11 @@ export function escapeHTML(value: string) {
         value;
 }
 
-export function isDefined(value: any) {
+export function isDefined(value: any, allowNull = false) {
+    if (allowNull) {
+        return value !== undefined;
+    }
+
     return value !== undefined && value !== null;
 }
 


### PR DESCRIPTION
It's the beginning of the work to close this issue #761 

By creating a <ng-option [value]="null">Label</ng-option> the option is selected if the formControl is set to null.
By switching and coming back to this ng-option, the formControl is set to null again.

Working only in single ng-select, not multiple.

Sometimes, the itemsList._items is empty onInit when it's trying to findItem, so we have to setValue of formControl in ngAfterViewInit (that's strange behaviour, for me when ngOptions change that should retry to findItem but that's not doing it, only on writeValue).

For the moment it only works by setting <ng-option> manually, not by passing [items] to <ng-select>, because there is a check on $ngOptionValue.

The logic behind the code, is :
- in _isValidWriteValue, we return true for null value
- in _handleWriteValue, in select callback, we try to findItem for value null
- in findItems, we check if value is null, if that's the case we return item.value?.$ngOptionValue === null
- in _updateNgModel, we transform object with $ngOptionValue: null to null

There is a lot of improvements to do, it's only working for single ng-select and with ng-option set manually, but I want to have your opinion on the logic before doing more work.

That's my first PR on GitHub, sorry if I'm doing it wrong.