### PR TITLE
fix: add themes directory to package.json exports

### DIFF
--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -27,7 +27,8 @@
     },
     "./scss/material.theme": {
       "style": "./scss/material.theme.scss"
-    }
+    },
+    "./themes/": "./themes/"
   },
   "peerDependencies": {
     "@angular/common": ">=13.0.0 <14.0.0",


### PR DESCRIPTION
This PR enables importing files from the "themes" directory when using Yarn with PnP. When used, the "exports" field in a package.json is meant to conceal all files not specified in "exports". Until now the exclusion of the "themes" directory wasn't an apparent issue because no other package manager/strategy is able to enforce disallowing importing files not specified in the "exports" field but Yarn with PnP enforces it.

https://nodejs.org/api/packages.html#packages_exports
https://github.com/jkrems/proposal-pkg-exports/

fixes #2065