### PR TITLE
fix: added more descriptive example for adding tag via promise

### DIFF
--- a/src/demo/app/examples/tags-backend-example/tags-backend-example.component.html
+++ b/src/demo/app/examples/tags-backend-example/tags-backend-example.component.html
@@ -1,7 +1,7 @@
 <p><b>[addTag]</b> also accepts promise if you need to verify new option with backend</p>
 
 <ng-select [items]="companies"
-           [addTag]="addTagPromise"
+           [addTag]="hardBoundAddTagPromiseFunction"
            multiple="true"
            bindLabel="name"
            [loading]="loading"

--- a/src/demo/app/examples/tags-backend-example/tags-backend-example.component.ts
+++ b/src/demo/app/examples/tags-backend-example/tags-backend-example.component.ts
@@ -1,16 +1,35 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Injectable, OnInit } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ExampleBackendService {
+    addTag(name: string) {
+        return new Promise((resolve) => {
+            // Simulate backend call.
+            setTimeout(() => {
+                resolve({ id: 5, name, valid: true });
+            }, 1000);
+        });
+    }
+}
 
 @Component({
     selector: 'tags-backend-example',
     templateUrl: './tags-backend-example.component.html',
-    styleUrls: ['./tags-backend-example.component.scss']
+    styleUrls: ['./tags-backend-example.component.scss'],
 })
 export class TagsBackendExampleComponent implements OnInit {
-
     selectedCompanies;
     companies: any[] = [];
     loading = false;
     companiesNames = ['Uber', 'Microsoft', 'Flexigen'];
+
+    // function passed to [addTag] needs to have 'this' hard bound
+    // otherwise it will silently fail
+    hardBoundAddTagPromiseFunction = this.addTagPromise.bind(this);
+    // this would also work
+    // hardBoundAddTagPromiseFunction = (name: string) => this.addTagPromise(name);
+
+    constructor(private backendService: ExampleBackendService) {}
 
     ngOnInit() {
         this.companiesNames.forEach((c, i) => {
@@ -18,14 +37,11 @@ export class TagsBackendExampleComponent implements OnInit {
         });
     }
 
-    addTagPromise(name) {
-        return new Promise((resolve) => {
-            this.loading = true;
-            // Simulate backend call.
-            setTimeout(() => {
-                resolve({ id: 5, name: name, valid: true });
-                this.loading = false;
-            }, 1000);
-        })
+    async addTagPromise(name) {
+        this.loading = true;
+        const result = await this.backendService.addTag(name);
+        this.loading = false;
+
+        return result;
     }
 }


### PR DESCRIPTION
When function is passed to addTag input, it silently fails if _this_ is not hard bound as _this_ will dynamically bind to NgSelectComponent instance.
Example is updated to explicitly show that hard bind is needed, it also shows more realistic use case (injected service).

I guess documentation should be updated as well to state this fact.

 