### PR TITLE
feat: add setting to specify document events that will close dropdown panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ map: {
 | [inputAttrs] | `{ [key: string]: string }` |  `-` | no | Pass custom attributes to underlying `input` element |
 | [tabIndex] | `number` |  `-` | no | Set tabindex on ng-select |
 | [keyDownFn] | `($event: KeyboardEvent) => bool` |  `true` | no | Provide custom keyDown function. Executed before default handler. Return false to suppress execution of default key down handlers  |
+| [closeTriggers] | `string[]` |  `['touchstart', 'mousedown']` | no | List of events outside component that will close dropdown panel |
 
 ### Outputs
 

--- a/src/ng-select/lib/config.service.ts
+++ b/src/ng-select/lib/config.service.ts
@@ -15,4 +15,5 @@ export class NgSelectConfig {
     bindLabel: string;
     appearance = 'underline';
     clearSearchOnAdd: boolean;
+    closeTriggers: string[] = ['touchstart', 'mousedown'];
 }

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -59,6 +59,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
     @Input() headerTemplate: TemplateRef<any>;
     @Input() footerTemplate: TemplateRef<any>;
     @Input() filterValue: string = null;
+    @Input() closeTriggers: string[] = ['touchstart', 'mousedown'];
 
     @Output() update = new EventEmitter<any[]>();
     @Output() scroll = new EventEmitter<{ start: number; end: number }>();
@@ -224,10 +225,10 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
         }
 
         this._zone.runOutsideAngular(() => {
-            merge(
-                fromEvent(this._document, 'touchstart', { capture: true }),
-                fromEvent(this._document, 'mousedown', { capture: true })
-            ).pipe(takeUntil(this._destroy$))
+            const triggers$ =  this.closeTriggers.map(eventName => fromEvent(this._document, eventName, { capture: true }));
+
+            merge(...triggers$)
+                .pipe(takeUntil(this._destroy$))
                 .subscribe($event => this._checkToClose($event));
         });
     }

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -80,6 +80,7 @@
                    [filterValue]="searchTerm"
                    [items]="itemsList.filteredItems"
                    [markedItem]="itemsList.markedItem"
+                   [closeTriggers]="closeTriggers"
                    (update)="viewPortItems = $event"
                    (scroll)="scroll.emit($event)"
                    (scrollToEnd)="scrollToEnd.emit($event)"

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -106,6 +106,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     @Input() searchWhileComposing = true;
     @Input() minTermLength = 0;
     @Input() editableSearchTerm = false;
+    @Input() closeTriggers: string[];
     @Input() keyDownFn = (_: KeyboardEvent) => true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
@@ -962,5 +963,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
         this.bindValue = this.bindValue || config.bindValue;
         this.bindLabel = this.bindLabel || config.bindLabel;
         this.appearance = this.appearance || config.appearance;
+        this.closeTriggers = this.closeTriggers || config.closeTriggers;
     }
 }


### PR DESCRIPTION
Add setting to specify document events that will close dropdown panel.

As example it allows to make dropdown panel to close on document `scroll` event, to mimic default `<select>` behavior.