### PR TITLE
fix: backspace empty filter clears model (#2121)

### DIFF
--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2270,7 +2270,7 @@ describe('NgSelectComponent', () => {
                 expect(select.itemsList.filteredItems[0].label).toBe('Kaunas');
                 select.filter('');
                 tickAndDetectChanges(fixture);
-                expect(select.itemsList.filteredItems.length).toBe(2);
+                expect(select.itemsList.filteredItems.length).toBe(3);
             }));
         });
     });
@@ -2775,6 +2775,31 @@ describe('NgSelectComponent', () => {
                 })
             ];
             expect(fixture.componentInstance.select.itemsList.filteredItems).toEqual(result);
+        }));
+
+        it('should clear the model if search term is empty', fakeAsync(() => {
+            const fixture = createTestingModule(
+                NgSelectGroupingTestComponent,
+                `<ng-select [items]="accounts"
+                    groupBy="country"
+                    bindLabel="name"
+                    [(ngModel)]="selectedAccount">
+                </ng-select>`
+            );
+
+            const spy = spyOn(fixture.componentInstance.select, 'clearModel');
+
+            tickAndDetectChanges(fixture);
+            fixture.componentInstance.select.filter('adam');
+            tickAndDetectChanges(fixture);
+
+            const filteredItems = fixture.componentInstance.select.itemsList.filteredItems;
+            expect(filteredItems.length).toBe(2);
+
+            fixture.componentInstance.select.filter('');
+            tickAndDetectChanges(fixture);
+
+            expect(spy).toHaveBeenCalled();
         }));
 
         describe('with typeahead', () => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -584,6 +584,10 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             }
         }
 
+        if (!this.searchTerm) {
+            this.clearModel();
+        }
+
         this.searchEvent.emit({ term, items: this.itemsList.filteredItems.map(x => x.value) });
         this.open();
     }

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -458,9 +458,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             this.select(item);
         }
 
-        if (this._editableSearchTerm) {
-            this._setSearchTermFromItems();
-        }
+        this._setSearchTermFromItems();
 
         this._onSelectionChanged();
     }
@@ -597,9 +595,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             return;
         }
 
-        if (this._editableSearchTerm) {
-            this._setSearchTermFromItems();
-        }
+        this._setSearchTermFromItems();
 
         this.element.classList.add('ng-select-focused');
         this.focusEvent.emit($event);
@@ -612,9 +608,8 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
         if (!this.isOpen && !this.disabled) {
             this._onTouched();
         }
-        if (this._editableSearchTerm) {
-            this._setSearchTermFromItems();
-        }
+        this._setSearchTermFromItems();
+
         this.focused = false;
     }
 
@@ -632,6 +627,10 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     }
 
     private _setSearchTermFromItems() {
+        if (!this._editableSearchTerm) {
+            return;
+        }
+
         const selected = this.selectedItems && this.selectedItems[0];
         this.searchTerm = (selected && selected.label) || null;
     }
@@ -742,6 +741,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
         } else {
             select(ngModel);
         }
+        this._setSearchTermFromItems();
     }
 
     private _handleKeyPresses() {


### PR DESCRIPTION
Fixes a bug that after removing the filter with backspace the last selected value appears again

Fixes #2121 