### PR TITLE
feat: extend appendTo to work in shadow dom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ travis_rsa
 travis_rsa.pub
 .vscode/**
 dist.tgz
+.history

--- a/src/demo/app/examples/append-to-shadow-root-example/append-to-shadow-root-example.component.html
+++ b/src/demo/app/examples/append-to-shadow-root-example/append-to-shadow-root-example.component.html
@@ -1,0 +1,14 @@
+<p>By default <b>appendTo</b> is used to append dropdown into document scope.
+    However when working with ShadowDom isolation - that doesn't work well.</p>
+<p>ShadowDom has shadowRoot inside which it makes sense to append dropdown - to apply ng-select styles injected into shadow dom.</p>
+<p>Using <b>appendToShadowRoot</b> it's possible to set shadowRoot parent to append dropdown in. 
+    Usually that will be web component name or just name of element where ShadowDom isolation is enabled</p>
+<sample-shadow-component>
+    <ng-select [items]="people | async"
+               appendToShadowRoot="sample-shadow-component"
+               appendTo=".shadow-container"
+               bindLabel="company"
+               placeholder="Select item"
+               [(ngModel)]="selected">
+    </ng-select>
+</sample-shadow-component>

--- a/src/demo/app/examples/append-to-shadow-root-example/append-to-shadow-root-example.component.ts
+++ b/src/demo/app/examples/append-to-shadow-root-example/append-to-shadow-root-example.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { DataService } from '../data.service';
+
+@Component({
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: 'append-to-shadow-root-example',
+    templateUrl: './append-to-shadow-root-example.component.html',
+    styleUrls: ['./append-to-shadow-root-example.component.scss']
+})
+export class AppendToShadowRootExampleComponent implements OnInit {
+
+    people: any = [];
+    selected: any;
+    selected2: any;
+    selected3: any;
+
+    constructor(private dataService: DataService) {
+    }
+
+    ngOnInit() {
+        this.people = this.dataService.getPeople();
+    }
+
+}

--- a/src/demo/app/examples/append-to-shadow-root-example/sample-shadow-component/sample-shadow-component.component.html
+++ b/src/demo/app/examples/append-to-shadow-root-example/sample-shadow-component/sample-shadow-component.component.html
@@ -1,0 +1,5 @@
+<div class="shadow-container">
+    <p><b>ng-select</b> shadow theme: <i>ant.design.theme</i></p>
+    <ng-content></ng-content>
+</div>
+

--- a/src/demo/app/examples/append-to-shadow-root-example/sample-shadow-component/sample-shadow-component.component.scss
+++ b/src/demo/app/examples/append-to-shadow-root-example/sample-shadow-component/sample-shadow-component.component.scss
@@ -1,0 +1,5 @@
+@import '../../../../../ng-select/themes/ant.design.theme.scss';
+
+.shadow-container {
+    position: relative;
+}

--- a/src/demo/app/examples/append-to-shadow-root-example/sample-shadow-component/sample-shadow-component.component.ts
+++ b/src/demo/app/examples/append-to-shadow-root-example/sample-shadow-component/sample-shadow-component.component.ts
@@ -1,0 +1,12 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+    encapsulation: ViewEncapsulation.ShadowDom,
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: 'sample-shadow-component',
+    templateUrl: './sample-shadow-component.component.html',
+    styleUrls: ['./sample-shadow-component.component.scss']
+})
+export class SampleShadowComponentComponent {
+    constructor() { }
+}

--- a/src/demo/app/examples/examples.module.ts
+++ b/src/demo/app/examples/examples.module.ts
@@ -4,6 +4,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgOptionHighlightModule } from '@ng-select/ng-option-highlight';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { AppendToExampleComponent } from './append-to-example/append-to-example.component';
+import { AppendToShadowRootExampleComponent } from './append-to-shadow-root-example/append-to-shadow-root-example.component';
 import { BindingsCustomExampleComponent } from './bindings-custom-example/bindings-custom-example.component';
 import { BindingsDefaultExampleComponent } from './bindings-default-example/bindings-default-example.component';
 import { BindingsNestedExampleComponent } from './bindings-nested-example/bindings-nested-example.component';
@@ -30,6 +31,7 @@ import { MultiSelectHiddenExampleComponent } from './multi-select-hidden-example
 import { MultiSelectLimitExampleComponent } from './multi-select-limit-example/multi-select-limit-example.component';
 import { MultiSelectTemplateExampleComponent } from './multi-select-template-example/multi-select-template-example.component';
 import { OutputEventsExampleComponent } from './output-events-example/output-events-example.component';
+import { SampleShadowComponentComponent } from './append-to-shadow-root-example/sample-shadow-component/sample-shadow-component.component';
 import { SearchAutocompleteExampleComponent } from './search-autocomplete-example/search-autocomplete-example.component';
 import { SearchCustomExampleComponent } from './search-custom-example/search-custom-example.component';
 import { SearchDefaultExampleComponent } from './search-default-example/search-default-example.component';
@@ -85,6 +87,8 @@ const examples = [DataSourceBackendExampleComponent,
     VirtualScrollExampleComponent,
     DropdownPositionExampleComponent,
     AppendToExampleComponent,
+    AppendToShadowRootExampleComponent,
+    SampleShadowComponentComponent,
     GroupDefaultExampleComponent,
     GroupFunctionExampleComponent,
     GroupSelectableExampleComponent,

--- a/src/demo/app/examples/examples.ts
+++ b/src/demo/app/examples/examples.ts
@@ -41,6 +41,7 @@ import { GroupSelectableExampleComponent } from './group-selectable-example/grou
 import { GroupSelectableHiddenExampleComponent } from './group-selectable-hidden-example/group-selectable-hidden-example.component';
 import { GroupChildrenExampleComponent } from './group-children-example/group-children-example.component';
 import { SearchEditableExampleComponent } from './search-editable-example/search-editable-example.component';
+import { AppendToShadowRootExampleComponent } from './append-to-shadow-root-example/append-to-shadow-root-example.component';
 
 export interface Example {
     component: any;
@@ -199,6 +200,11 @@ export const EXAMPLE_COMPONENTS: { [key: string]: Example } = {
     'append-to-example': {
         component: AppendToExampleComponent,
         title: 'Append to position'
+    },
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    'append-to-shadow-root-example': {
+        component: AppendToShadowRootExampleComponent,
+        title: 'Append to shadow root'
     },
     'group-default-example': {
         component: GroupDefaultExampleComponent,

--- a/src/demo/app/routes.ts
+++ b/src/demo/app/routes.ts
@@ -35,5 +35,10 @@ export const appRoutes: Routes = [
         component: RouteViewerComponent,
         data: { title: 'Append to element', examples: 'append-to' }
     },
+    {
+        path: 'append-to-shadow-root',
+        component: RouteViewerComponent,
+        data: { title: 'Append to shadow root', examples: 'append-to-shadow-root' }
+    },
     { path: 'grouping', component: RouteViewerComponent, data: { title: 'Grouping', examples: 'group' } },
 ];

--- a/src/ng-select/lib/config.service.ts
+++ b/src/ng-select/lib/config.service.ts
@@ -10,6 +10,7 @@ export class NgSelectConfig {
     clearAllText = 'Clear all';
     disableVirtualScroll = true;
     openOnEnter = true;
+    appendToShadowRoot: string;
     appendTo: string;
     bindValue: string;
     bindLabel: string;

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -53,6 +53,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
     @Input() items: NgOption[] = [];
     @Input() markedItem: NgOption;
     @Input() position: DropdownPosition = 'auto';
+    @Input() appendToShadowRoot: string;
     @Input() appendTo: string;
     @Input() bufferAmount;
     @Input() virtualScroll = false;
@@ -238,7 +239,8 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
         }
 
         const path = $event.path || ($event.composedPath && $event.composedPath());
-        if ($event.target && $event.target.shadowRoot && path && path[0] && this._select.contains(path[0])) {
+        if ($event.target && $event.target.shadowRoot && path && path[0] && (
+            this._select.contains(path[0]) || this.appendToShadowRoot && this._parent.contains(path[0]))) {
             return;
         }
 
@@ -391,7 +393,10 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
 
-        this._parent = document.querySelector(this.appendTo);
+        const queryContext = this.appendToShadowRoot ?
+            document.querySelector(this.appendToShadowRoot).shadowRoot :
+            document;
+        this._parent = queryContext.querySelector(this.appendTo);
         if (!this._parent) {
             throw new Error(`appendTo selector ${this.appendTo} did not found any parent element`);
         }

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -73,6 +73,7 @@
                    class="ng-dropdown-panel"
                    [virtualScroll]="virtualScroll"
                    [bufferAmount]="bufferAmount"
+                   [appendToShadowRoot]="appendToShadowRoot"
                    [appendTo]="appendTo"
                    [position]="dropdownPosition"
                    [headerTemplate]="headerTemplate"

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -83,6 +83,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     @Input() clearAllText: string;
     @Input() appearance: string;
     @Input() dropdownPosition: DropdownPosition = 'auto';
+    @Input() appendToShadowRoot: string;
     @Input() appendTo: string;
     @Input() loading = false;
     @Input() closeOnSelect = true;
@@ -958,6 +959,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             ? this.virtualScroll
             : isDefined(config.disableVirtualScroll) ? !config.disableVirtualScroll : false;
         this.openOnEnter = isDefined(this.openOnEnter) ? this.openOnEnter : config.openOnEnter;
+        this.appendToShadowRoot = this.appendToShadowRoot || config.appendToShadowRoot;
         this.appendTo = this.appendTo || config.appendTo;
         this.bindValue = this.bindValue || config.bindValue;
         this.bindLabel = this.bindLabel || config.bindLabel;


### PR DESCRIPTION
https://github.com/ng-select/ng-select/issues/2126
This merge request allows to adjust ng-select to work in scope of micro frontends & shadow dom.
Let's look at real case related to company-x:
- They have shell which hosts series of micro frontends. The purpose of shell is let the user get it, click on link and see micro frontend app inside
- There is micro frontend app "mfe-1" which uses ng-select inside. 
    - For isolation - mfe1 is shared as web component with view encapsulation 'ShadowDom' enabled.
    - mfe1 uses ng-select and injects css for it directly to web component css

With existing ng-select version - when ng-select gets opened - dropdown is appended to body. Okay, we can specify selector via appendTo, but it won't work for mfe1, because it's web component with ShadowDom. As result - styles for ng-select are hosted in ShadowDom and do not affect added dropdown in scope of document.

To resolve - it's needed to insert dropdown into ShadowDom as well.
This merge request provides new property **appendToShadowRoot** which allows to specify shadow root parent. And after that **appendTo** will work in context of ShadowRoot.