### PR TITLE
fix: setting focus to input element only if its not readonly, fixes 2133

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -484,7 +484,9 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     }
 
     focus() {
-        this.searchInput.nativeElement.focus();
+        if(!this.searchInput.nativeElement.readOnly){
+            this.searchInput.nativeElement.focus();
+        };
     }
 
     blur() {


### PR DESCRIPTION
This prevents safari 16.0 from jumping to the top as it seems Safari 16.0 doesn't like setting focus on a readonly element