### PR TITLE
fixed top value for ng-placeholder class

### DIFF
--- a/src/ng-select/themes/default.theme.scss
+++ b/src/ng-select/themes/default.theme.scss
@@ -199,7 +199,7 @@ $ng-select-input-text: #000000 !default;
                     }
                 }
                 .ng-placeholder {
-                    top: 5px;
+                    top: 8px;
                     padding-bottom: 5px;
                     padding-left: 3px;
                     @include rtl {


### PR DESCRIPTION
setting top at 5px was causing placeholder text to be raised up, which looked odd as place holder seems to be not aligned. have changed top value form 5px to 8px fix alignment issue.