### PR TITLE
feat: deselect option from dropdown in single select

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ map: {
 | [searchWhileComposing] | `boolean` | `true` | no | Whether items should be filtered while composition started |
 | [trackByFn] | `(item: any) => any` | `null` | no | Provide custom trackBy function |
 | [clearSearchOnAdd] | `boolean` | `true` | no | Clears search input when item is selected. Default `true`. Default `false` when **closeOnSelect** is `false` |
+| [deselectOnClick] | `boolean` | `false` | no | Deselects a selected item when it is clicked in the dropdown. Default `false`. Default `true` when **multiple** is `true` |
 | [editableSearchTerm] | `boolean` |  `false` | no | Allow to edit search query if option selected. Default `false`. Works only if multiple is `false`. |
 | [selectOnTab] | `boolean` | `false` | no | Select marked dropdown item using tab. Default `false`|
 | [openOnEnter] | `boolean` | `true` | no | Open dropdown using enter. Default `true`|

--- a/src/ng-select/lib/config.service.ts
+++ b/src/ng-select/lib/config.service.ts
@@ -15,4 +15,5 @@ export class NgSelectConfig {
     bindLabel: string;
     appearance = 'underline';
     clearSearchOnAdd: boolean;
+    deselectOnClick: boolean;
 }

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2305,6 +2305,133 @@ describe('NgSelectComponent', () => {
         });
     });
 
+    describe('Deselecting items', () => {
+        describe('Multiple', () => {
+            it('should not toggle selected item when deselectOnClick is false', fakeAsync(() => {
+                const fixture = createTestingModule(
+                    NgSelectTestComponent,
+                    `<ng-select [items]="cities"
+                        bindLabel="name"
+                        [multiple]="true"
+                        [deselectOnClick]="false">
+                    </ng-select>`);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                selectOption(fixture, KeyCode.ArrowDown, 2);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(2);
+
+                selectOption(fixture, KeyCode.ArrowDown, 1);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(2);
+                expect(fixture.componentInstance.select.selectedItems[0]).toEqual(jasmine.objectContaining({
+                    value: { id: 1, name: 'Vilnius' }
+                }));
+            }));
+
+            it('should toggle selected item when deselectOnClick is true', fakeAsync(() => {
+                const fixture = createTestingModule(
+                    NgSelectTestComponent,
+                    `<ng-select [items]="cities"
+                        bindLabel="name"
+                        [multiple]="true"
+                        [deselectOnClick]="true">
+                    </ng-select>`);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                selectOption(fixture, KeyCode.ArrowDown, 2);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(2);
+
+                selectOption(fixture, KeyCode.ArrowDown, 1);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(1);
+                expect(fixture.componentInstance.select.selectedItems[0]).toEqual(jasmine.objectContaining({
+                    value: { id: 3, name: 'Pabrade' }
+                }));
+            }));
+
+            it('should toggle selected item when deselectOnClick is undefined', fakeAsync(() => {
+                const fixture = createTestingModule(
+                    NgSelectTestComponent,
+                    `<ng-select [items]="cities"
+                        bindLabel="name"
+                        [multiple]="true">
+                    </ng-select>`);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                selectOption(fixture, KeyCode.ArrowDown, 2);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(2);
+
+                selectOption(fixture, KeyCode.ArrowDown, 1);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(1);
+                expect(fixture.componentInstance.select.selectedItems[0]).toEqual(jasmine.objectContaining({
+                    value: { id: 3, name: 'Pabrade' }
+                }));
+            }));
+        });
+
+        describe('Single', () => {
+            it('should not toggle selected item when deselectOnClick is false', fakeAsync(() => {
+                const fixture = createTestingModule(
+                    NgSelectTestComponent,
+                    `<ng-select [items]="cities"
+                        bindLabel="name"
+                        [deselectOnClick]="false">
+                    </ng-select>`);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(1);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(1);
+                expect(fixture.componentInstance.select.selectedItems[0]).toEqual(jasmine.objectContaining({
+                    value: { id: 1, name: 'Vilnius' }
+                }));
+            }));
+
+            it('should toggle selected item when deselectOnClick is true', fakeAsync(() => {
+                const fixture = createTestingModule(
+                    NgSelectTestComponent,
+                    `<ng-select [items]="cities"
+                        bindLabel="name"
+                        [deselectOnClick]="true">
+                    </ng-select>`);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(1);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(0);
+            }));
+
+            it('should not toggle selected item when deselectOnClick is undefined', fakeAsync(() => {
+                const fixture = createTestingModule(
+                    NgSelectTestComponent,
+                    `<ng-select [items]="cities"
+                        bindLabel="name">
+                    </ng-select>`);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(1);
+
+                selectOption(fixture, KeyCode.ArrowDown, 0);
+                tickAndDetectChanges(fixture);
+                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(1);
+                expect(fixture.componentInstance.select.selectedItems[0]).toEqual(jasmine.objectContaining({
+                    value: { id: 1, name: 'Vilnius' }
+                }));
+            }));
+        })
+    })
+
     describe('Tagging', () => {
         it('should select default tag', fakeAsync(() => {
             const fixture = createTestingModule(

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -150,6 +150,20 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
         this._clearSearchOnAdd = value;
     };
 
+    @Input()
+    get deselectOnClick() {
+        if (isDefined(this._deselectOnClick)) {
+            return this._deselectOnClick;
+        } else if (isDefined(this.config.deselectOnClick)) {
+            return this.config.deselectOnClick;
+        }
+        return this.multiple;
+    };
+
+    set deselectOnClick(value) {
+        this._deselectOnClick = value;
+    };
+
     // output events
     @Output('blur') blurEvent = new EventEmitter();
     @Output('focus') focusEvent = new EventEmitter();
@@ -205,6 +219,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     private _pressedKeys: string[] = [];
     private _compareWith: CompareWithFn;
     private _clearSearchOnAdd: boolean;
+    private _deselectOnClick: boolean;
     private _isComposing = false;
 
     private get _editableSearchTerm(): boolean {
@@ -452,7 +467,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             return;
         }
 
-        if (this.multiple && item.selected) {
+        if (this.deselectOnClick && item.selected) {
             this.unselect(item);
         } else {
             this.select(item);
@@ -843,7 +858,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     }
 
     private _onSelectionChanged() {
-        if (this.isOpen && this.multiple && this.appendTo) {
+        if (this.isOpen && this.deselectOnClick && this.appendTo) {
             // Make sure items are rendered.
             this._cd.detectChanges();
             this.dropdownPanel.adjustPosition();


### PR DESCRIPTION
This feature enables deselecting an option from the dropdown when `multiple` is `false`. The user can
click on a selected option, which will deselect that option instead of closing the dropdown.

Fixes #2053