### PR TITLE
Reflect model value changes with editableSearchTerm enabled

### DIFF
--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3091,6 +3091,49 @@ describe('NgSelectComponent', () => {
                 const allOptions = select.element.querySelectorAll('.ng-dropdown-panel .ng-option');
                 expect(allOptions.length).toEqual(fixture.componentInstance.cities.length);
             }));
+
+            it('should reflect changes to model value', fakeAsync(() => {
+                const fixture = createTestingModule(
+                    NgSelectTestComponent,
+                    `<ng-select [items]="cities"
+                        [typeahead]="filter"
+                        [editableSearchTerm]="true"
+                        bindValue="id"
+                        bindLabel="name"
+                        [(ngModel)]="selectedCity">
+                    </ng-select>`);
+                const select = fixture.componentInstance.select;
+                const input = select.searchInput.nativeElement;
+                const selectedCity = fixture.componentInstance.cities[0];
+                const searchTerm = selectedCity.name;
+                tickAndDetectChanges(fixture);
+                input.focus();
+                input.value = searchTerm;
+                input.dispatchEvent(new Event('input'));
+                tickAndDetectChanges(fixture);
+                expect(select.searchTerm).toEqual(searchTerm);
+                const firstOption = select.element.querySelector('.ng-dropdown-panel .ng-option');
+                expect(firstOption.textContent).toEqual(selectedCity.name);
+                let event = new MouseEvent('mousedown', { bubbles: true });
+                firstOption.dispatchEvent(event);
+                event = new MouseEvent('click', { bubbles: true });
+                firstOption.dispatchEvent(event);
+                tickAndDetectChanges(fixture);
+                expect(fixture.componentInstance.selectedCity).toBe(selectedCity.id);
+                const newSelectedCity = fixture.componentInstance.cities[1];
+                fixture.componentInstance.selectedCity = newSelectedCity.id;
+                tickAndDetectChanges(fixture);
+                expect(select.selectedValues[0].id).toBe(newSelectedCity.id);
+                tickAndDetectChanges(fixture);
+                const valueLabel = select.element.querySelector('.ng-value-label');
+                expect(valueLabel.textContent).toBe(newSelectedCity.name);
+                expect(input.value).toBe(newSelectedCity.name);
+                fixture.componentInstance.selectedCity = null;
+                tickAndDetectChanges(fixture);
+                expect(select.selectedValues.length).toBe(0);
+                tickAndDetectChanges(fixture);
+                expect(input.value).toBe('');
+            }));
         });
     });
 

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3134,6 +3134,45 @@ describe('NgSelectComponent', () => {
                 tickAndDetectChanges(fixture);
                 expect(input.value).toBe('');
             }));
+
+            it('should not reflect changes to model value while dropdown is open', fakeAsync(() => {
+                const fixture = createTestingModule(
+                    NgSelectTestComponent,
+                    `<ng-select [items]="cities"
+                        [typeahead]="filter"
+                        [editableSearchTerm]="true"
+                        bindValue="id"
+                        bindLabel="name"
+                        [(ngModel)]="selectedCity">
+                    </ng-select>`);
+                const select = fixture.componentInstance.select;
+                const input = select.searchInput.nativeElement;
+                const selectedCity = fixture.componentInstance.cities[0];
+                const searchTerm = selectedCity.name;
+                tickAndDetectChanges(fixture);
+                input.focus();
+                input.value = searchTerm;
+                input.dispatchEvent(new Event('input'));
+                tickAndDetectChanges(fixture);
+                expect(select.searchTerm).toEqual(searchTerm);
+                const firstOption = select.element.querySelector('.ng-dropdown-panel .ng-option');
+                expect(firstOption.textContent).toEqual(selectedCity.name);
+                let event = new MouseEvent('mousedown', { bubbles: true });
+                firstOption.dispatchEvent(event);
+                event = new MouseEvent('click', { bubbles: true });
+                firstOption.dispatchEvent(event);
+                tickAndDetectChanges(fixture);
+                expect(fixture.componentInstance.selectedCity).toBe(selectedCity.id);
+                input.value = 'test';
+                input.focus();
+                input.dispatchEvent(new Event('input'));
+                tickAndDetectChanges(fixture);
+                fixture.componentInstance.selectedCity = null;
+                tickAndDetectChanges(fixture);
+                expect(select.selectedValues.length).toBe(0);
+                tickAndDetectChanges(fixture);
+                expect(input.value).toBe('test');
+            }));
         });
     });
 

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -712,33 +712,35 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
     }
 
     private _handleWriteValue(ngModel: any | any[]) {
-        if (!this._isValidWriteValue(ngModel)) {
-            return
+        if (this._isValidWriteValue(ngModel)) {
+            const select = (val: any) => {
+                let item = this.itemsList.findItem(val);
+                if (item) {
+                    this.itemsList.select(item);
+                } else {
+                    const isValObject = isObject(val);
+                    const isPrimitive = !isValObject && !this.bindValue;
+                    if ((isValObject || isPrimitive)) {
+                        this.itemsList.select(this.itemsList.mapItem(val, null));
+                    } else if (this.bindValue) {
+                        item = {
+                            [this.bindLabel]: null,
+                            [this.bindValue]: val
+                        };
+                        this.itemsList.select(this.itemsList.mapItem(item, null));
+                    }
+                }
+            };
+
+            if (this.multiple) {
+                (<any[]>ngModel).forEach(item => select(item));
+            } else {
+                select(ngModel);
+            }
         }
 
-        const select = (val: any) => {
-            let item = this.itemsList.findItem(val);
-            if (item) {
-                this.itemsList.select(item);
-            } else {
-                const isValObject = isObject(val);
-                const isPrimitive = !isValObject && !this.bindValue;
-                if ((isValObject || isPrimitive)) {
-                    this.itemsList.select(this.itemsList.mapItem(val, null));
-                } else if (this.bindValue) {
-                    item = {
-                        [this.bindLabel]: null,
-                        [this.bindValue]: val
-                    };
-                    this.itemsList.select(this.itemsList.mapItem(item, null));
-                }
-            }
-        };
-
-        if (this.multiple) {
-            (<any[]>ngModel).forEach(item => select(item));
-        } else {
-            select(ngModel);
+        if (this._editableSearchTerm) {
+            this._setSearchTermFromItems();
         }
     }
 

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -739,7 +739,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
             }
         }
 
-        if (this._editableSearchTerm) {
+        if (this._editableSearchTerm && !this.isOpen) {
             this._setSearchTermFromItems();
         }
     }


### PR DESCRIPTION
Fixes #2179 by updating the search term displayed in the input element when the model value changes. Includes a failing test as the first commit to demonstrate the problem and the solution.

When `editableSearchTerm` is enabled, the input is displayed instead of `.ng-value-label`. While the latter updated in response to model value updates, the former did not. 

As a consequence, changes to the model value while you are typing would be disruptive. I feel like this could be a contentious decision, but I chose to skip the search term update when the dropdown is open because I don't think we have a good distinction available for "is typing."

It would be wonderful if this could be hotfixed for earlier versions; I'm using 10.x  which is also the version used in the stackblitz example on #2179.