### PR TITLE
fix(ng-option): Remove event emits full ng-select model instead of direct value

### DIFF
--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -1662,6 +1662,7 @@ describe('NgSelectComponent', () => {
 
             it('should remove last selected value when multiple', fakeAsync(() => {
                 const remove = spyOn(select.removeEvent, 'emit');
+                const removedItem = fixture.componentInstance.cities[2];
                 fixture.componentInstance.multiple = true;
                 fixture.componentInstance.cities = [...fixture.componentInstance.cities];
                 tickAndDetectChanges(fixture);
@@ -1673,7 +1674,7 @@ describe('NgSelectComponent', () => {
                     value: fixture.componentInstance.cities[1]
                 })];
                 expect(select.selectedItems).toEqual(result);
-                expect(remove).toHaveBeenCalled();
+                expect(remove).toHaveBeenCalledWith(removedItem);
             }));
 
             it('should not remove last selected if it is disabled', fakeAsync(() => {

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3528,7 +3528,7 @@ describe('NgSelectComponent', () => {
 
             fixture.componentInstance.select.unselect(fixture.componentInstance.cities[0]);
 
-            expect(fixture.componentInstance.onRemove).toHaveBeenCalledWith(fixture.componentInstance.cities[0]);
+            expect(fixture.componentInstance.onRemove).toHaveBeenCalledWith(fixture.componentInstance.cities[0].value);
         }));
 
         it('should fire clear when model is cleared using clear icon', fakeAsync(() => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -516,7 +516,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
         this.itemsList.unselect(item);
         this.focus();
         this._updateNgModel();
-        this.removeEvent.emit(item);
+        this.removeEvent.emit(item.value);
     }
 
     selectTag() {


### PR DESCRIPTION
A potential solution for the following issue: #2288 