### PR TITLE
fix:2372 generate unique htmlId when items with already grouped children array provided

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -237,7 +237,7 @@ export class ItemsList {
             label: isDefined(label) ? label.toString() : '',
             value,
             disabled: item.disabled,
-            htmlId: `${this._ngSelect.dropdownId}-${index}`,
+            htmlId: `${this._ngSelect.dropdownId}-${item.id ?? index}`,
         };
     }
 


### PR DESCRIPTION
Fixing issue https://github.com/ng-select/ng-select/issues/2372