### PR TITLE
Migrate to standalone components

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,29 @@ npm install --save @ng-select/ng-select
 ```shell
 yarn add @ng-select/ng-select
 ```
-### Step 2: Import the NgSelectModule and angular FormsModule module:
-```js
+### Step 2: 
+
+#### Standalone: Import NgSelectComponent and other necessary directives directly:
+```typescript
+import { NgSelectModule, NgLabelTemplateDirective, NgOptionTemplateDirective } from '@ng-select/ng-select';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'example',
+  standalone: true,
+  template: './example.component.html',
+  styleUrl: './example.component.scss',
+  imports: [
+    NgSelectComponent,
+    NgOptionTemplateDirective,
+    NgLabelTemplateDirective,
+  ],
+})
+export class ExampleComponent {}
+```
+
+#### NgModule: Import the NgSelectModule and angular FormsModule module:
+```typescript
 import { NgSelectModule } from '@ng-select/ng-select';
 import { FormsModule } from '@angular/forms';
 

--- a/src/ng-option-highlight/lib/ng-option-highlight.directive.spec.ts
+++ b/src/ng-option-highlight/lib/ng-option-highlight.directive.spec.ts
@@ -4,16 +4,18 @@ import { NgOptionHighlightDirective } from './ng-option-highlight.directive';
 import { By } from '@angular/platform-browser';
 
 @Component({
-	template: `
-		<span id="test1" [ngOptionHighlight]="term">My text is highlighted</span>
-		<span id="test2" [ngOptionHighlight]="term">My text is not highlighted</span>
-		<span id="test3" [ngOptionHighlight]="term">My text is highlighted</span>
-		<span id="test4" [ngOptionHighlight]="term">My ťëxť is highlighted text</span>
-		@if (showNew) {
-			<span id="test5" [ngOptionHighlight]="term">New label</span>
-		}
-		<span id="test6" [ngOptionHighlight]="term">+My text is) high\\lighted</span>
-	`,
+    template: `
+        <span id="test1" [ngOptionHighlight]="term">My text is highlighted</span>
+        <span id="test2" [ngOptionHighlight]="term">My text is not highlighted</span>
+        <span id="test3" [ngOptionHighlight]="term">My text is highlighted</span>
+        <span id="test4" [ngOptionHighlight]="term">My ťëxť is highlighted text</span>
+        @if (showNew) {
+            <span id="test5" [ngOptionHighlight]="term">New label</span>
+        }
+        <span id="test6" [ngOptionHighlight]="term">+My text is) high\\lighted</span>
+    `,
+    imports: [NgOptionHighlightDirective],
+    standalone: true
 })
 class TestComponent {
 	term: string;
@@ -23,10 +25,10 @@ class TestComponent {
 describe('NgOptionHighlightDirective', () => {
 	let fixture: ComponentFixture<TestComponent>;
 
-	beforeEach(() => {
-		fixture = TestBed.configureTestingModule({
-			declarations: [NgOptionHighlightDirective, TestComponent],
-		}).createComponent(TestComponent);
+    beforeEach(() => {
+        fixture = TestBed.configureTestingModule({
+    imports: [TestComponent],
+}).createComponent(TestComponent);
 
 		fixture.detectChanges();
 	});

--- a/src/ng-option-highlight/lib/ng-option-highlight.directive.ts
+++ b/src/ng-option-highlight/lib/ng-option-highlight.directive.ts
@@ -3,6 +3,7 @@ import { AfterViewInit, Directive, ElementRef, Input, OnChanges, Renderer2 } fro
 
 @Directive({
 	selector: '[ngOptionHighlight]',
+    standalone: true,
 })
 export class NgOptionHighlightDirective implements OnChanges, AfterViewInit {
 	@Input('ngOptionHighlight') term: string;

--- a/src/ng-option-highlight/lib/ng-option-highlight.directive.ts
+++ b/src/ng-option-highlight/lib/ng-option-highlight.directive.ts
@@ -1,4 +1,3 @@
-import * as searchHelper from './search-helper';
 import { AfterViewInit, Directive, ElementRef, Input, OnChanges, Renderer2 } from '@angular/core';
 
 @Directive({

--- a/src/ng-option-highlight/lib/ng-option-highlight.module.ts
+++ b/src/ng-option-highlight/lib/ng-option-highlight.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { NgOptionHighlightDirective } from './ng-option-highlight.directive';
 
 @NgModule({
-	declarations: [NgOptionHighlightDirective],
+	imports: [NgOptionHighlightDirective],
 	exports: [NgOptionHighlightDirective],
 })
 export class NgOptionHighlightModule {}

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -38,18 +38,18 @@ const SCROLL_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? animatio
     template: `
         @if (headerTemplate) {
           <div class="ng-dropdown-header">
-            <ng-container [ngTemplateOutlet]="headerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>
+            <ng-container [ngTemplateOutlet]="headerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"/>
           </div>
         }
         <div #scroll role="listbox" class="ng-dropdown-panel-items scroll-host">
             <div #padding [class.total-padding]="virtualScroll"></div>
             <div #content [class.scrollable-content]="virtualScroll && items.length">
-                <ng-content></ng-content>
+                <ng-content/>
             </div>
         </div>
         @if (footerTemplate) {
           <div class="ng-dropdown-footer">
-            <ng-container [ngTemplateOutlet]="footerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>
+            <ng-container [ngTemplateOutlet]="footerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"/>
           </div>
         }
     `,

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT } from '@angular/common';
+import {DOCUMENT, NgTemplateOutlet} from '@angular/common';
 import {
 	booleanAttribute,
 	ChangeDetectionStrategy,
@@ -34,24 +34,28 @@ const SCROLL_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? animatio
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	selector: 'ng-dropdown-panel',
-	template: `
-		@if (headerTemplate) {
-			<div class="ng-dropdown-header">
-				<ng-container [ngTemplateOutlet]="headerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>
-			</div>
-		}
-		<div #scroll role="listbox" class="ng-dropdown-panel-items scroll-host">
-			<div #padding [class.total-padding]="virtualScroll"></div>
-			<div #content [class.scrollable-content]="virtualScroll && items.length">
-				<ng-content></ng-content>
-			</div>
-		</div>
-		@if (footerTemplate) {
-			<div class="ng-dropdown-footer">
-				<ng-container [ngTemplateOutlet]="footerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>
-			</div>
-		}
-	`,
+	standalone: true,
+    template: `
+        @if (headerTemplate) {
+          <div class="ng-dropdown-header">
+            <ng-container [ngTemplateOutlet]="headerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>
+          </div>
+        }
+        <div #scroll role="listbox" class="ng-dropdown-panel-items scroll-host">
+            <div #padding [class.total-padding]="virtualScroll"></div>
+            <div #content [class.scrollable-content]="virtualScroll && items.length">
+                <ng-content></ng-content>
+            </div>
+        </div>
+        @if (footerTemplate) {
+          <div class="ng-dropdown-footer">
+            <ng-container [ngTemplateOutlet]="footerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>
+          </div>
+        }
+    `,
+    imports: [
+        NgTemplateOutlet,
+    ],
 })
 export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 	@Input() items: NgOption[] = [];

--- a/src/ng-select/lib/ng-option.component.ts
+++ b/src/ng-select/lib/ng-option.component.ts
@@ -13,8 +13,9 @@ import { Subject } from 'rxjs';
 
 @Component({
 	selector: 'ng-option',
-	changeDetection: ChangeDetectionStrategy.OnPush,
-	template: `<ng-content></ng-content>`,
+	standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `<ng-content/>`,
 })
 export class NgOptionComponent implements OnChanges, AfterViewChecked, OnDestroy {
 	@Input() value: any;

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -31,18 +31,19 @@ import { takeUntil, startWith, tap, debounceTime, map, filter } from 'rxjs/opera
 import { Subject, merge } from 'rxjs';
 
 import {
-	NgOptionTemplateDirective,
-	NgLabelTemplateDirective,
-	NgHeaderTemplateDirective,
-	NgFooterTemplateDirective,
-	NgOptgroupTemplateDirective,
-	NgNotFoundTemplateDirective,
-	NgTypeToSearchTemplateDirective,
-	NgLoadingTextTemplateDirective,
-	NgMultiLabelTemplateDirective,
-	NgTagTemplateDirective,
-	NgLoadingSpinnerTemplateDirective,
-	NgPlaceholderTemplateDirective,
+    NgOptionTemplateDirective,
+    NgLabelTemplateDirective,
+    NgHeaderTemplateDirective,
+    NgFooterTemplateDirective,
+    NgOptgroupTemplateDirective,
+    NgNotFoundTemplateDirective,
+    NgTypeToSearchTemplateDirective,
+    NgLoadingTextTemplateDirective,
+    NgMultiLabelTemplateDirective,
+    NgTagTemplateDirective,
+    NgLoadingSpinnerTemplateDirective,
+    NgPlaceholderTemplateDirective,
+    NgItemLabelDirective,
 } from './ng-templates.directive';
 
 import { ConsoleService } from './console.service';
@@ -55,6 +56,7 @@ import { NgOptionComponent } from './ng-option.component';
 import { SelectionModelFactory } from './selection-model';
 import { NgSelectConfig } from './config.service';
 import { NgDropdownPanelService } from './ng-dropdown-panel.service';
+import {NgClass, NgTemplateOutlet} from "@angular/common";
 
 export const SELECTION_MODEL_FACTORY = new InjectionToken<SelectionModelFactory>('ng-select-selection-model');
 export type AddTagFn = (term: string) => any | Promise<any>;
@@ -63,9 +65,10 @@ export type GroupValueFn = (key: string | any, children: any[]) => string | any;
 
 @Component({
 	selector: 'ng-select',
-	templateUrl: './ng-select.component.html',
-	styleUrls: ['./ng-select.component.scss'],
-	providers: [
+	standalone: true,
+    templateUrl: './ng-select.component.html',
+    styleUrls: ['./ng-select.component.scss'],
+    providers: [
 		{
 			provide: NG_VALUE_ACCESSOR,
 			useExisting: forwardRef(() => NgSelectComponent),
@@ -75,6 +78,12 @@ export type GroupValueFn = (key: string | any, children: any[]) => string | any;
 	],
 	encapsulation: ViewEncapsulation.None,
 	changeDetection: ChangeDetectionStrategy.OnPush,
+imports: [
+        NgTemplateOutlet,
+        NgItemLabelDirective,
+        NgDropdownPanelComponent,
+        NgClass,
+    ],
 })
 export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterViewInit, ControlValueAccessor {
 	@Input() bindLabel: string;

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -25,6 +25,7 @@ import {
 	Attribute,
 	booleanAttribute,
 	numberAttribute,
+    Optional,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { takeUntil, startWith, tap, debounceTime, map, filter } from 'rxjs/operators';
@@ -53,7 +54,7 @@ import { NgOption, KeyCode, DropdownPosition } from './ng-select.types';
 import { newId } from './id';
 import { NgDropdownPanelComponent } from './ng-dropdown-panel.component';
 import { NgOptionComponent } from './ng-option.component';
-import { SelectionModelFactory } from './selection-model';
+import { DefaultSelectionModelFactory, SelectionModelFactory } from './selection-model';
 import { NgSelectConfig } from './config.service';
 import { NgDropdownPanelService } from './ng-dropdown-panel.service';
 import {NgClass, NgTemplateOutlet} from "@angular/common";
@@ -78,7 +79,7 @@ export type GroupValueFn = (key: string | any, children: any[]) => string | any;
 	],
 	encapsulation: ViewEncapsulation.None,
 	changeDetection: ChangeDetectionStrategy.OnPush,
-imports: [
+    imports: [
         NgTemplateOutlet,
         NgItemLabelDirective,
         NgDropdownPanelComponent,
@@ -265,13 +266,13 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 		@Attribute('class') public classes: string,
 		@Attribute('autofocus') private autoFocus: any,
 		public config: NgSelectConfig,
-		@Inject(SELECTION_MODEL_FACTORY) newSelectionModel: SelectionModelFactory,
+		@Inject(SELECTION_MODEL_FACTORY) @Optional() newSelectionModel: SelectionModelFactory | undefined,
 		_elementRef: ElementRef<HTMLElement>,
 		private _cd: ChangeDetectorRef,
 		private _console: ConsoleService,
 	) {
 		this._mergeGlobalConfig(config);
-		this.itemsList = new ItemsList(this, newSelectionModel());
+		this.itemsList = new ItemsList(this, newSelectionModel ? newSelectionModel() : DefaultSelectionModelFactory());
 		this.element = _elementRef.nativeElement;
 	}
 

--- a/src/ng-select/lib/ng-select.module.ts
+++ b/src/ng-select/lib/ng-select.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { NgDropdownPanelComponent } from './ng-dropdown-panel.component';
 import { NgOptionComponent } from './ng-option.component';
-import { NgSelectComponent } from './ng-select.component';
+import { NgSelectComponent, SELECTION_MODEL_FACTORY } from './ng-select.component';
 import {
 	NgFooterTemplateDirective,
 	NgHeaderTemplateDirective,
@@ -17,6 +17,7 @@ import {
 	NgTypeToSearchTemplateDirective,
 	NgPlaceholderTemplateDirective,
 } from './ng-templates.directive';
+import { DefaultSelectionModelFactory } from "./selection-model";
 
 @NgModule({
 	imports: [

--- a/src/ng-select/lib/ng-select.module.ts
+++ b/src/ng-select/lib/ng-select.module.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { NgDropdownPanelComponent } from './ng-dropdown-panel.component';
 import { NgOptionComponent } from './ng-option.component';
@@ -6,22 +5,22 @@ import { NgSelectComponent, SELECTION_MODEL_FACTORY } from './ng-select.componen
 import {
 	NgFooterTemplateDirective,
 	NgHeaderTemplateDirective,
-	NgLabelTemplateDirective,
-	NgLoadingSpinnerTemplateDirective,
-	NgLoadingTextTemplateDirective,
-	NgMultiLabelTemplateDirective,
-	NgNotFoundTemplateDirective,
-	NgOptgroupTemplateDirective,
-	NgOptionTemplateDirective,
-	NgTagTemplateDirective,
 	NgItemLabelDirective,
+    NgLabelTemplateDirective,
+    NgLoadingSpinnerTemplateDirective,
+    NgLoadingTextTemplateDirective,
+    NgMultiLabelTemplateDirective,
+    NgNotFoundTemplateDirective,
+    NgOptgroupTemplateDirective,
+    NgOptionTemplateDirective,
+    NgTagTemplateDirective,
 	NgTypeToSearchTemplateDirective,
 	NgPlaceholderTemplateDirective,
 } from './ng-templates.directive';
-import { DefaultSelectionModelFactory } from './selection-model';
+import {DefaultSelectionModelFactory} from './selection-model';
 
 @NgModule({
-	declarations: [
+	imports: [
 		NgDropdownPanelComponent,
 		NgOptionComponent,
 		NgSelectComponent,
@@ -39,7 +38,6 @@ import { DefaultSelectionModelFactory } from './selection-model';
 		NgLoadingSpinnerTemplateDirective,
 		NgItemLabelDirective,
 	],
-	imports: [CommonModule],
 	exports: [
 		NgSelectComponent,
 		NgOptionComponent,

--- a/src/ng-select/lib/ng-select.module.ts
+++ b/src/ng-select/lib/ng-select.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { NgDropdownPanelComponent } from './ng-dropdown-panel.component';
 import { NgOptionComponent } from './ng-option.component';
-import { NgSelectComponent, SELECTION_MODEL_FACTORY } from './ng-select.component';
+import { NgSelectComponent } from './ng-select.component';
 import {
 	NgFooterTemplateDirective,
 	NgHeaderTemplateDirective,
@@ -17,7 +17,6 @@ import {
 	NgTypeToSearchTemplateDirective,
 	NgPlaceholderTemplateDirective,
 } from './ng-templates.directive';
-import {DefaultSelectionModelFactory} from './selection-model';
 
 @NgModule({
 	imports: [

--- a/src/ng-select/lib/ng-templates.directive.ts
+++ b/src/ng-select/lib/ng-templates.directive.ts
@@ -16,8 +16,8 @@ export class NgItemLabelDirective implements OnChanges {
 	}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-option-tmp]',
     standalone: true,
 })
@@ -25,8 +25,8 @@ export class NgOptionTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-optgroup-tmp]',
     standalone: true,
 })
@@ -34,8 +34,8 @@ export class NgOptgroupTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-label-tmp]',
     standalone: true,
 })
@@ -43,8 +43,8 @@ export class NgLabelTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-multi-label-tmp]',
     standalone: true,
 })
@@ -52,8 +52,8 @@ export class NgMultiLabelTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-header-tmp]',
     standalone: true,
 })
@@ -61,8 +61,8 @@ export class NgHeaderTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-footer-tmp]',
     standalone: true,
 })
@@ -70,8 +70,8 @@ export class NgFooterTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-notfound-tmp]',
     standalone: true,
 })
@@ -85,8 +85,8 @@ export class NgPlaceholderTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-typetosearch-tmp]',
     standalone: true,
 })
@@ -94,8 +94,8 @@ export class NgTypeToSearchTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-loadingtext-tmp]',
     standalone: true,
 })
@@ -103,8 +103,8 @@ export class NgLoadingTextTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-tag-tmp]',
     standalone: true,
 })
@@ -112,8 +112,8 @@ export class NgTagTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[ng-loadingspinner-tmp]',
     standalone: true,
 })

--- a/src/ng-select/lib/ng-templates.directive.ts
+++ b/src/ng-select/lib/ng-templates.directive.ts
@@ -79,8 +79,11 @@ export class NgNotFoundTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
-// eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-placeholder-tmp]' })
+@Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
+    selector: '[ng-placeholder-tmp]',
+    standalone: true,
+})
 export class NgPlaceholderTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }

--- a/src/ng-select/lib/ng-templates.directive.ts
+++ b/src/ng-select/lib/ng-templates.directive.ts
@@ -1,7 +1,10 @@
 import { Directive, ElementRef, Input, OnChanges, SimpleChanges, TemplateRef } from '@angular/core';
 import { escapeHTML } from './value-utils';
 
-@Directive({ selector: '[ngItemLabel]' })
+@Directive({
+    selector: '[ngItemLabel]',
+    standalone: true,
+})
 export class NgItemLabelDirective implements OnChanges {
 	@Input() ngItemLabel: string;
 	@Input() escape = true;
@@ -14,43 +17,64 @@ export class NgItemLabelDirective implements OnChanges {
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-option-tmp]' })
+@Directive({
+    selector: '[ng-option-tmp]',
+    standalone: true,
+})
 export class NgOptionTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-optgroup-tmp]' })
+@Directive({
+    selector: '[ng-optgroup-tmp]',
+    standalone: true,
+})
 export class NgOptgroupTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-label-tmp]' })
+@Directive({
+    selector: '[ng-label-tmp]',
+    standalone: true,
+})
 export class NgLabelTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-multi-label-tmp]' })
+@Directive({
+    selector: '[ng-multi-label-tmp]',
+    standalone: true,
+})
 export class NgMultiLabelTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-header-tmp]' })
+@Directive({
+    selector: '[ng-header-tmp]',
+    standalone: true,
+})
 export class NgHeaderTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-footer-tmp]' })
+@Directive({
+    selector: '[ng-footer-tmp]',
+    standalone: true,
+})
 export class NgFooterTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-notfound-tmp]' })
+@Directive({
+    selector: '[ng-notfound-tmp]',
+    standalone: true,
+})
 export class NgNotFoundTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
@@ -62,25 +86,37 @@ export class NgPlaceholderTemplateDirective {
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-typetosearch-tmp]' })
+@Directive({
+    selector: '[ng-typetosearch-tmp]',
+    standalone: true,
+})
 export class NgTypeToSearchTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-loadingtext-tmp]' })
+@Directive({
+    selector: '[ng-loadingtext-tmp]',
+    standalone: true,
+})
 export class NgLoadingTextTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-tag-tmp]' })
+@Directive({
+    selector: '[ng-tag-tmp]',
+    standalone: true,
+})
 export class NgTagTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }
 
 // eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[ng-loadingspinner-tmp]' })
+@Directive({
+    selector: '[ng-loadingspinner-tmp]',
+    standalone: true,
+})
 export class NgLoadingSpinnerTemplateDirective {
 	constructor(public template: TemplateRef<any>) {}
 }


### PR DESCRIPTION
Migration to standalone components. Closes #2392

It is backwards compatible: `NgSelectModule`, that exports all components and directives, can be imported as before

But now components and directives can be imported one by one as well

Sub PRs to make review easier, to be merged before merging this one
* https://github.com/pkurcx/ng-select/pull/1
* https://github.com/pkurcx/ng-select/pull/2