### PR TITLE
feat: add floating placeholder support to ng-select

### DIFF
--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -4,13 +4,13 @@
 	[class.ng-has-value]="hasValue"
 	class="ng-select-container">
 	<div class="ng-value-container">
-		@if(selectedItems.length === 0 && !searchTerm) {
-        <ng-template #defaultPlaceholderTemplate>
-            <div class="ng-placeholder">{{ placeholder }}</div>
-        </ng-template>
-        <ng-template
-			[ngTemplateOutlet]="placeholderTemplate || defaultPlaceholderTemplate">
-        </ng-template>
+		@if((selectedItems.length === 0 && !searchTerm) || (floatPlaceholder)) {
+            <div class="ng-placeholder" [ngClass]="{'ng-float-placeholder': floatPlaceholder}">
+                <ng-template #defaultPlaceholderTemplate>{{placeholder}}</ng-template>
+                <ng-template
+                    [ngTemplateOutlet]="placeholderTemplate || defaultPlaceholderTemplate">
+                </ng-template>
+            </div>
 		}
 		
 		@if ((!multiLabelTemplate || !multiple) && selectedItems.length > 0) {

--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -62,7 +62,6 @@
 		display: flex;
 		outline: none;
 		overflow: hidden;
-		position: relative;
 		width: 100%;
 
 		.ng-value-container {

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2329,7 +2329,7 @@ describe('NgSelectComponent', () => {
 			fixture.componentInstance.selectedCity = undefined;
 			tickAndDetectChanges(fixture);
 			expect(fixture.debugElement.query(By.css('.placeholder-template')).nativeElement.innerHTML).toBe('Select your city');
-			expect(fixture.debugElement.query(By.css('.ng-placeholder'))).toBeFalsy();
+			expect(fixture.debugElement.query(By.css('.ng-placeholder'))).toBeTruthy();
 		}));
 
 		it('should update ng-option label', fakeAsync(() => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -91,6 +91,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 	@Input() bindValue: string;
 	@Input({ transform: booleanAttribute }) markFirst = true;
 	@Input() placeholder: string;
+	@Input() floatPlaceholder: boolean = false;
 	@Input() notFoundText: string;
 	@Input() typeToSearchText: string;
 	@Input() preventToggleOnRightClick: boolean = false;

--- a/src/ng-select/themes/ant.design.theme.scss
+++ b/src/ng-select/themes/ant.design.theme.scss
@@ -40,6 +40,12 @@ $ng-select-marked: #e6f7ff !default;
 		.ng-select-container {
 			border-color: $ng-select-highlight;
 		}
+		.ng-value-container .ng-placeholder {
+			&.ng-float-placeholder {
+				transform: translateY(-1.27em) scale(0.75) perspective(100px) translateZ(0.001px);
+				color: $ng-select-highlight;
+			}
+		}
 	}
 	&.ng-select-disabled {
 		> .ng-select-container {
@@ -57,6 +63,23 @@ $ng-select-marked: #e6f7ff !default;
 	}
 	.ng-has-value .ng-placeholder {
 		display: none;
+	}
+
+	.ng-has-value,
+	&.ng-select-filtered .ng-select-container {
+		.ng-placeholder {
+			&.ng-float-placeholder {
+				display: initial;
+			}
+		}
+	}
+	.ng-has-value,
+	&.ng-select-opened {
+		.ng-placeholder {
+			&.ng-float-placeholder {
+				transform: translateY(-1.27em) scale(0.75) perspective(100px) translateZ(0.001px);
+			}
+		}
 	}
 
 	&.ng-select-clearable .ng-select-container.ng-has-value:hover {
@@ -96,6 +119,19 @@ $ng-select-marked: #e6f7ff !default;
 			.ng-placeholder {
 				font-size: 14px;
 				color: lighten($ng-select-primary-text, 60);
+				&.ng-float-placeholder {
+					position: absolute;
+					transform-origin: left 0;
+					padding-inline: 6px;
+					background-color: #ffffff;
+					transition:
+						transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),
+						color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),
+						width 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+					@include rtl {
+						transform-origin: right 0;
+					}
+				}
 			}
 		}
 	}
@@ -114,6 +150,13 @@ $ng-select-marked: #e6f7ff !default;
 					@include rtl {
 						padding-right: 10px;
 						padding-left: 50px;
+					}
+				}
+				.ng-placeholder {
+					font-size: 14px;
+					color: lighten($ng-select-primary-text, 60);
+					&.ng-float-placeholder {
+						transform: translateY(-1em) scale(0.75) perspective(100px) translateZ(0.001px);
 					}
 				}
 			}
@@ -180,6 +223,11 @@ $ng-select-marked: #e6f7ff !default;
 					height: 20px;
 					margin-top: -10px;
 					margin-left: 6px;
+
+					&.ng-float-placeholder {
+						padding-inline: 6px;
+						padding-bottom: 0;
+					}
 				}
 				.ng-input {
 					height: 24px;

--- a/src/ng-select/themes/default.theme.scss
+++ b/src/ng-select/themes/default.theme.scss
@@ -32,6 +32,7 @@ $ng-select-dropdown-option-disabled: lighten($ng-select-primary-text, 60) !defau
 $ng-select-input-text: #000000 !default;
 
 .ng-select {
+	position: relative;
 	&.ng-select-opened {
 		> .ng-select-container {
 			background: $ng-select-bg;
@@ -78,6 +79,12 @@ $ng-select-input-text: #000000 !default;
 			border-color: $ng-select-highlight;
 			box-shadow: $ng-select-box-shadow;
 		}
+		.ng-value-container .ng-placeholder {
+			&.ng-float-placeholder {
+				transform: translateY(-1.1em) scale(0.75) perspective(100px) translateZ(0.001px);
+				color: $ng-select-highlight;
+			}
+		}
 	}
 	&.ng-select-disabled {
 		> .ng-select-container {
@@ -87,6 +94,24 @@ $ng-select-input-text: #000000 !default;
 	.ng-has-value .ng-placeholder {
 		display: none;
 	}
+
+	.ng-has-value,
+	&.ng-select-filtered .ng-select-container {
+		.ng-placeholder {
+			&.ng-float-placeholder {
+				display: initial;
+			}
+		}
+	}
+	.ng-has-value,
+	&.ng-select-opened {
+		.ng-placeholder {
+			&.ng-float-placeholder {
+				transform: translateY(-1.1em) scale(0.75) perspective(100px) translateZ(0.001px);
+			}
+		}
+	}
+
 	.ng-select-container {
 		color: $ng-select-primary-text;
 		background-color: $ng-select-bg;
@@ -106,6 +131,19 @@ $ng-select-input-text: #000000 !default;
 			}
 			.ng-placeholder {
 				color: $ng-select-placeholder;
+				&.ng-float-placeholder {
+					position: absolute;
+					transform-origin: left 0;
+					padding-inline: 6px;
+					background-color: #ffffff;
+					transition:
+						transform 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),
+						color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),
+						width 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+					@include rtl {
+						transform-origin: right 0;
+					}
+				}
 			}
 		}
 	}
@@ -204,6 +242,10 @@ $ng-select-input-text: #000000 !default;
 					top: 5px;
 					padding-bottom: 5px;
 					padding-left: 3px;
+					&.ng-float-placeholder {
+						padding-inline: 6px;
+						padding-bottom: 0;
+					}
 					@include rtl {
 						padding-right: 3px;
 						padding-left: 0;

--- a/src/ng-select/themes/material.theme.scss
+++ b/src/ng-select/themes/material.theme.scss
@@ -71,6 +71,7 @@ $ng-select-bg: #ffffff !default;
 		color: $ng-select-primary-text;
 		align-items: baseline;
 		min-height: 51.5px;
+		position: relative;
 		&:after {
 			border-bottom: thin solid rgba(0, 0, 0, 0.42);
 			content: '';


### PR DESCRIPTION
### Overview
This PR introduces a floating placeholder feature to the `ng-select` component. The placeholder will animate and float above the input field when a user interacts with the component or when an option is selected.

### Technical Details
- Added a new `floatPlaceholder` input property to enable or disable the feature.
- Updated the CSS to include animation and transition effects for the floating placeholder.
- Modified the template to dynamically move the placeholder based on the state of the input field.
- Ensured backward compatibility by keeping the default behavior unchanged when `floatPlaceholder` is not set.
