### PR TITLE
fix: Sync StackBlitz app template selector with component selector

### DIFF
--- a/src/demo/app/shared/example-viewer/stackblitz-button/stackblitz.service.ts
+++ b/src/demo/app/shared/example-viewer/stackblitz-button/stackblitz.service.ts
@@ -102,6 +102,6 @@ export class StackblitzService {
 	}
 
 	private get _exampleTemplate() {
-		return `<${this._exampleName}></${this._exampleName}>`;
+		return `<ng-${this._exampleName}></ng-${this._exampleName}>`;
 	}
 }


### PR DESCRIPTION
Resolves [#2463]

**Problem**:  When clicking the "StackBlitz" button of any of the examples in the [demo](https://ng-select.github.io/ng-select), it opens a StackBlitz example. However, the ng-select component itself doesn't appear to render in the StackBlitz even though all the dependencies are installed.

**Analysis**: Every StackBlitz example generated seems to show a discrepancy between the selector name in the component decorator and the template name in the app component's decorator.

**Resolution**: Prepend (ng-) while generating the template name for the app component's decorator


 

