### PR TITLE
Fix addTag and virtual scroll dropdown panel height

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -55,6 +55,7 @@ const SCROLL_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? animatio
 })
 export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 	@Input() items: NgOption[] = [];
+	@Input() showAddTag: boolean = false;
 	@Input() markedItem: NgOption;
 	@Input() position: DropdownPosition = 'auto';
 	@Input() appendTo: string;
@@ -136,7 +137,11 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 	ngOnChanges(changes: SimpleChanges) {
 		if (changes.items) {
 			const change = changes.items;
-			this._onItemsChange(change.currentValue, change.firstChange);
+			this._onItemsOrShowAddTagChange(change.currentValue, this.showAddTag, change.firstChange);
+		}
+		if (changes.showAddTag) {
+			const change = changes.showAddTag;
+			this._onItemsOrShowAddTagChange(this.items, change.currentValue, change.firstChange);
 		}
 	}
 
@@ -250,11 +255,13 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 		this._zone.run(() => this.outsideClick.emit());
 	}
 
-	private _onItemsChange(items: NgOption[], firstChange: boolean) {
+	private _onItemsOrShowAddTagChange(items: NgOption[], showAddTag: boolean, firstChange: boolean) {
 		this.items = items || [];
 		this._scrollToEndFired = false;
 		this.itemsLength = items.length;
-
+		if (showAddTag && !(items.length === 0)) {
+			this.itemsLength++;
+		}
 		if (this.virtualScroll) {
 			this._updateItemsRange(firstChange);
 		} else {

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -83,6 +83,7 @@
 		[footerTemplate]="footerTemplate"
 		[filterValue]="searchTerm"
 		[items]="itemsList.filteredItems"
+		[showAddTag]="showAddTag"
 		[markedItem]="itemsList.markedItem"
 		(update)="viewPortItems = $event"
 		(scroll)="scroll.emit($event)"


### PR DESCRIPTION
Fixes #1700: The height of the dropdown panel does not consider the add tag entries when virtual scroll is active.

Explanation and and reproducible example is included in the referenced issue. The issue is still reproducible with the current version.

The issue is that the addTag is not included in the regular list of items but rendered separately. As the height calculation is based solely on the number of regular items, the addTag is not considered. To compensate for that I passed the information whether the button is displayed or not as an additional parameter to the `NgDropdownPanelComponent` and increment the `itemsLength` in case the addTag is displayed.