### PR TITLE
Fix API Description for 'bufferAmount'

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ map: {
 | addTagText                  | `string`                                             | `Add item`          | no | Set custom text when using tagging                                                                                                                                                             |
 | appearance                  | `string`                                             | `underline`         | no | Allows to select dropdown appearance. Set to `outline` to add border instead of underline (applies only to Material theme)                                                                     |
 | appendTo                    | `string`                                             | null                | no | Append dropdown to body or any other element using css selector. For correct positioning `body` should have `position:relative`                                                                |
-| bufferAmount                | `string`                                             | null                | no | Append dropdown to body or any other element using css selector. For correct positioning `body` should have `position:relative`                                                                |
+| bufferAmount                | `number`                                             | 4                | no | Used in virtual scrolling, the `bufferAmount` property controls the number of items preloaded in the background to ensure smoother and more seamless scrolling. |
 | bindValue                   | `string`                                             | `-`                 | no | Object property to use for selected model. By default binds to whole object.                                                                                                                   |
 | bindLabel                   | `string`                                             | `label`             | no | Object property to use for label. Default `label`                                                                                                                                              |
 | [closeOnSelect]             | `boolean`                                            | true                | no | Whether to close the menu when a value is selected                                                                                                                                             |
@@ -303,7 +303,7 @@ data types. That means if you do object mutations like:
 
 ```javascript
 this.items.push({id: 1, name: 'New item'})
-``` 
+```
 
 Component will not detect a change. Instead you need to do:
 


### PR DESCRIPTION
In 'README.md' the API description for 'bufferAmount' is incorrect.