### PR TITLE
Add support for clearing a disabled option that is currently selected

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -78,7 +78,7 @@ export class ItemsList {
 		}
 		const multiple = this._ngSelect.multiple;
 		if (!multiple) {
-			this.clearSelected();
+			this.clearSelected(false);
 		}
 
 		this._selectionModel.select(item, multiple, this._ngSelect.selectableGroupAsModel);
@@ -117,7 +117,7 @@ export class ItemsList {
 		return option;
 	}
 
-	clearSelected(keepDisabled = false) {
+	clearSelected(keepDisabled: boolean) {
 		this._selectionModel.clear(keepDisabled);
 		this._items.forEach((item) => {
 			item.selected = keepDisabled && item.selected && item.disabled;

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -45,7 +45,7 @@ import {
 	NgPlaceholderTemplateDirective,
 	NgTagTemplateDirective,
 	NgTypeToSearchTemplateDirective,
-	NgClearButtonTemplateDirective
+	NgClearButtonTemplateDirective,
 } from './ng-templates.directive';
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
@@ -126,6 +126,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 	@Input() @HostBinding('class.ng-select-taggable') addTag: boolean | AddTagFn = false;
 	@Input({ transform: booleanAttribute }) @HostBinding('class.ng-select-searchable') searchable = true;
 	@Input({ transform: booleanAttribute }) @HostBinding('class.ng-select-clearable') clearable = true;
+	@Input({ transform: booleanAttribute }) clearableSelectedDisabledOption = true;
 	@Input() @HostBinding('class.ng-select-opened') isOpen?: boolean = false;
 	// output events
 	@Output('blur') blurEvent = new EventEmitter();
@@ -321,7 +322,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 
 	ngOnChanges(changes: SimpleChanges) {
 		if (changes.multiple) {
-			this.itemsList.clearSelected();
+			this.itemsList.clearSelected(!this.clearableSelectedDisabledOption);
 		}
 		if (changes.items) {
 			this._setItems(changes.items.currentValue || []);
@@ -450,7 +451,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 
 	handleClearClick() {
 		if (this.hasValue) {
-			this.itemsList.clearSelected(true);
+			this.itemsList.clearSelected(!this.clearableSelectedDisabledOption);
 			this._updateNgModel();
 		}
 		this._clearSearch();
@@ -464,12 +465,12 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 		if (!this.clearable) {
 			return;
 		}
-		this.itemsList.clearSelected();
+		this.itemsList.clearSelected(!this.clearableSelectedDisabledOption);
 		this._updateNgModel();
 	}
 
 	writeValue(value: any | any[]): void {
-		this.itemsList.clearSelected();
+		this.itemsList.clearSelected(!this.clearableSelectedDisabledOption);
 		this._handleWriteValue(value);
 		this._cd.markForCheck();
 	}


### PR DESCRIPTION
This PR addresses the issue described in https://github.com/ng-select/ng-select/issues/2431.

In an ng-select component that is **not** disabled, there can be an option that **is** disabled. The clear all button will not clear any disabled field that is currently selected. While the ng-select is not disabled that would mean the actual input field actions should be available (ie: the clear all button).

If people prefer to keep the functionality as it works right now; I've added a component @Input field `clearableSelectedDisabledOption` which defaults to true, but can be set to false by adding `[clearableSelectedDisabledOption]="false"`