### PR TITLE
fix: fix scroll behavior for ng-select used in shadow dom

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -30,10 +30,10 @@ const CSS_POSITIONS: Readonly<string[]> = ['top', 'right', 'bottom', 'left'];
 const SCROLL_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? animationFrameScheduler : asapScheduler;
 
 @Component({
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None,
-    selector: 'ng-dropdown-panel',
-    template: `
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	encapsulation: ViewEncapsulation.None,
+	selector: 'ng-dropdown-panel',
+	template: `
 		@if (headerTemplate) {
 			<div class="ng-dropdown-header">
 				<ng-container [ngTemplateOutlet]="headerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }" />
@@ -51,7 +51,7 @@ const SCROLL_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? animatio
 			</div>
 		}
 	`,
-    imports: [NgTemplateOutlet]
+	imports: [NgTemplateOutlet],
 })
 export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 	@Input() items: NgOption[] = [];
@@ -159,7 +159,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 			return;
 		}
 
-		let scrollTo;
+		let scrollTo: number;
 		if (this.virtualScroll) {
 			const itemHeight = this._panelService.dimensions.itemHeight;
 			scrollTo = this._panelService.getScrollTo(index * itemHeight, itemHeight, this._lastScrollPosition);
@@ -212,15 +212,10 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 
 	private _handleScroll() {
 		this._zone.runOutsideAngular(() => {
-			fromEvent(this.scrollElementRef.nativeElement, 'scroll')
+			fromEvent(this._scrollablePanel, 'scroll')
 				.pipe(takeUntil(this._destroy$), auditTime(0, SCROLL_SCHEDULER))
-				.subscribe((e: { path; composedPath; target }) => {
-					const path = e.path || (e.composedPath && e.composedPath());
-					if (!path || (path.length === 0 && !e.target)) {
-						return;
-					}
-					const scrollTop = !path || path.length === 0 ? e.target.scrollTop : path[0].scrollTop;
-					this._onContentScrolled(scrollTop);
+				.subscribe(() => {
+					this._onContentScrolled(this._scrollablePanel.scrollTop);
 				});
 		});
 	}


### PR DESCRIPTION
This PR fixes scroll behavior for ng-select used in shadow dom and also simplifies the way scroll event is handled inside ng-dropdown-panel.

Fixes https://github.com/ng-select/ng-select/issues/2511