### PR TITLE
feat: expose selected values to screen readers

### DIFF
--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -3,7 +3,7 @@
 	[class.ng-appearance-outline]="appearance === 'outline'"
 	[class.ng-has-value]="hasValue"
 	class="ng-select-container">
-	<div class="ng-value-container">
+	<div [attr.id]="id + '-aria-selected'" class="ng-value-container">
 		@if ((selectedItems.length === 0 && !searchTerm) || fixedPlaceholder) {
 			<ng-template #defaultPlaceholderTemplate>
 				<div class="ng-placeholder">{{ placeholder }}</div>
@@ -12,7 +12,7 @@
 		}
 
 		@if ((!multiLabelTemplate || !multiple) && selectedItems.length > 0) {
-			@for (item of selectedItems; track trackByOption($index, item)) {
+			@for (item of selectedItems; track trackByOption($index, item); let last = $last) {
 				<div [class.ng-value-disabled]="item.disabled" class="ng-value">
 					<ng-template #defaultLabelTemplate>
 						<span class="ng-value-icon left" (click)="unselect(item)" aria-hidden="true">×</span>
@@ -23,6 +23,9 @@
 						[ngTemplateOutletContext]="{ item: item.value, clear: clearItem, label: item.label }">
 					</ng-template>
 				</div>
+				@if (!last) {
+					<span class="ng-visually-hidden">&#44;</span>
+				}
 			}
 		}
 
@@ -42,6 +45,7 @@
 				(input)="filter(searchInput.value)"
 				[attr.aria-activedescendant]="isOpen ? itemsList?.markedItem?.htmlId : null"
 				[attr.aria-controls]="isOpen ? dropdownId : null"
+				[attr.aria-describedby]="id + '-aria-selected'"
 				[attr.aria-expanded]="isOpen"
 				[attr.aria-label]="ariaLabel"
 				[attr.id]="labelForId"

--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -65,6 +65,17 @@
 		position: relative;
 		width: 100%;
 
+		.ng-visually-hidden {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			margin: -1px;
+			padding: 0;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			border: 0;
+		}
+
 		.ng-value-container {
 			display: flex;
 			flex: 1;

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -3654,9 +3654,12 @@ describe('NgSelectComponent', () => {
 				`<ng-select [items]="cities"
                         labelForId="lbl"
                         (change)="onChange($event)"
-                        bindLabel="name">
+                        bindLabel="name"
+												[multiple]="true"
+												[(ngModel)]="selectedCities">
                 </ng-select>`,
 			);
+
 			select = fixture.componentInstance.select;
 			input = fixture.debugElement.query(By.css('input')).nativeElement;
 			comboBoxDiv = fixture.debugElement.query(By.css('.ng-input')).nativeElement;
@@ -3731,6 +3734,44 @@ describe('NgSelectComponent', () => {
 			input.setAttribute('aria-label', 'test');
 			expect(input.getAttribute('aria-label')).toBe('test');
 		});
+
+		it('should link the input to the ng-value-container via aria-describedby', () => {
+			const valueContainer = fixture.debugElement.nativeElement.querySelector('.ng-value-container');
+
+			expect(valueContainer.id).toBe(`${select.id}-aria-selected`);
+			expect(input.getAttribute('aria-describedby')).toBe(`${select.id}-aria-selected`);
+		});
+
+		it('should visually hide the separator for the selected items', fakeAsync(() => {
+			fixture.componentInstance.selectedCities = [fixture.componentInstance.cities[0], fixture.componentInstance.cities[1]];
+
+			tickAndDetectChanges(fixture);
+			tickAndDetectChanges(fixture);
+
+			const valueContainer = fixture.debugElement.nativeElement.querySelector('.ng-value-container');
+			const visuallyHiddenSpans = valueContainer.querySelectorAll('.ng-visually-hidden');
+
+			expect(visuallyHiddenSpans.length).toBe(1);
+		}));
+
+		it('should present the selected items in a screenreader-friendly format', fakeAsync(() => {
+			fixture.componentInstance.selectedCities = [
+				fixture.componentInstance.cities[0],
+				fixture.componentInstance.cities[1],
+				fixture.componentInstance.cities[2],
+			];
+
+			tickAndDetectChanges(fixture);
+			tickAndDetectChanges(fixture);
+
+			const valueContainer = fixture.debugElement.nativeElement.querySelector('.ng-value-container');
+			const visibleText = Array.from<HTMLElement>(valueContainer.querySelectorAll(':not([aria-hidden="true"])'))
+				.filter((el) => el.children.length === 0)
+				.map((el) => el.textContent.trim())
+				.join('');
+
+			expect(visibleText).toBe('Vilnius,Kaunas,Pabrade');
+		}));
 	});
 
 	describe('Output events', () => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -83,6 +83,9 @@ export type GroupValueFn = (key: string | any, children: any[]) => string | any;
 	imports: [NgTemplateOutlet, NgItemLabelDirective, NgDropdownPanelComponent, NgClass],
 })
 export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterViewInit, ControlValueAccessor {
+	public static nextId = 0;
+	public id = `ng-select-${NgSelectComponent.nextId++}`;
+
 	@Input() ariaLabelDropdown: string = 'Options List';
 	@Input() bindLabel: string;
 	@Input() bindValue: string;


### PR DESCRIPTION
## Copilot summarization
This pull request enhances accessibility and user experience for the `NgSelectComponent` by adding ARIA attributes, improving screen reader support, and updating tests. Key changes include introducing unique IDs for ARIA attributes, visually hiding separators for better screen reader formatting, and ensuring selected items are presented in a screenreader-friendly format.

### Accessibility Improvements:
* Added a unique `id` property to `NgSelectComponent` and used it to link the input field to the selected items container via `aria-describedby`. (`src/ng-select/lib/ng-select.component.ts`, `src/ng-select/lib/ng-select.component.html`) [[1]](diffhunk://#diff-f4208411e590de4e21a942c948b48e10cbbf4786cfb5257e0e2aef22c239358eR86-R88) [[2]](diffhunk://#diff-b0ae60d30a7c815e10ae7029cded53d487b4fe94f98cfcb583cd1acf18550a95R48)
* Introduced visually hidden separators (`.ng-visually-hidden`) for better screen reader formatting of selected items. (`src/ng-select/lib/ng-select.component.html`, `src/ng-select/lib/ng-select.component.scss`) [[1]](diffhunk://#diff-b0ae60d30a7c815e10ae7029cded53d487b4fe94f98cfcb583cd1acf18550a95R26-R28) [[2]](diffhunk://#diff-b6336cc779a39d1d984168729b27eb1fab486686dfa762588cff1de9370c5f07R68-R78)

### Test Enhancements:
* Added tests to verify ARIA attributes (`aria-describedby`) link the input to the selected items container. (`src/ng-select/lib/ng-select.component.spec.ts`)
* Added tests to ensure separators are visually hidden and selected items are presented in a screenreader-friendly format. (`src/ng-select/lib/ng-select.component.spec.ts`)

These changes ensure improved accessibility and compliance with screen reader requirements while maintaining a seamless user experience.

fixes #2478

## Additional context
This PR will ensure the a value will be announced for:
- The placeholder
- A single item
- Multiple items
- Custom templates (that are not defined via `ng-multi-tmp`

This is done by using the `.ng-value-container` to describe the input to allow screenreaders to announce the selected values. This includes the additional element that adds a separator (`, `) between group items, which will be visually hidden, such that group values are announced as groups. Without this element a group of items will be announced as one long string.

I tested the solution using MacOS's voice over functionality. Since I work with a Mac, I was unable to verify this using NVDA or some other screen reader 🙇 

## Limitations
The additional element is not added when a custom multi-template is used in combination with the `multiple` option. It is up to the user to handle the separator for screenreaders in this case. 

In full disclosure, to quote `W3C` specification for [combobox](https://w3c.github.io/aria/#combobox)

> User agents MUST expose the value of elements with role combobox to [assistive technologies](https://w3c.github.io/aria/#dfn-assistive-technologies). The value of a combobox is represented by one of the following:
> 
> * If the combobox element is a host language element that provides a value, such as an HTML input element, the value of the combobox is the value of that element.
> * Otherwise, the value of the combobox is represented by its descendant elements and can be determined using the same method used to compute the name of a [button](https://w3c.github.io/aria/#button) from its descendant content.

In this case the `host language element` would be the input, but the value is not directly provided via the input. This would mean that a string needs to populate the input that represents the selected values, which is somewhat incompatible with how the `ng-select` behaves. Instead the `aria-describedby` is utilized to provide a description of the 'empty' input, which simulates as if the current value is announced.

Although not a pure solution, I was unable to find a cleaner approach 😊 