### PR TITLE
fix: disable unselect on disabled multiselect

### DIFF
--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -125,10 +125,12 @@
 	}
 
 	&.ng-select-multiple {
-		&.ng-select-disabled {
-			> .ng-select-container .ng-value-container .ng-value {
-				.ng-value-icon {
-					display: none;
+		&.ng-select-multiple {
+			.ng-select-disabled {
+				> .ng-select-container .ng-value-container .ng-value {
+					.ng-value-icon {
+						display: none;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Repeating the `.ng-select-multiple` class to increase specificity. This is necessary to override styles applied by themed CSS classes.

```css
// before: specificity: 0,7,0
.ng-select.ng-select-multiple.ng-select-disabled>.ng-select-container .ng-value-container .ng-value .ng-value-icon { }

// after: specificity: 0,8,0
.ng-select.ng-select-multiple.ng-select-multiple.ng-select-disabled>.ng-select-container .ng-value-container .ng-value .ng-value-icon { }

// to be overriden: specificity: 0,8,0
.default-theme[_nghost-ng-c3016505477] .ng-select.ng-select-multiple .ng-select-container .ng-value-container .ng-value .ng-value-icon { }
```

Fixes #2517.