### PR TITLE
fix: allow text selection when ng-select is disabled

### DIFF
--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -40,7 +40,9 @@
 			.ng-value-container {
 				.ng-placeholder,
 				.ng-value {
-					user-select: none;
+					position: relative;
+					z-index: 1001;
+					user-select: text;
 					cursor: default;
 				}
 			}

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -420,6 +420,10 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 	}
 
 	handleMousedown($event: MouseEvent) {
+		if (this.disabled) {
+			return;
+		}
+
 		if (this.preventToggleOnRightClick && $event.button === 2) {
 			return false;
 		}


### PR DESCRIPTION
Currently, when `ng-select` is disabled, you cannot select the label of a selected item (e.g. by double-clicking). 
In contrast, a standard disabled `<input>` still allows text selection.

Allowing text selection is useful when building read-only (disabled) forms, 
as it lets users copy selected values for reuse.

Fixes #2107.