### PR TITLE
Update deprecated usage of observers in typeahead check (RxJS v8 compatibility)

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -303,7 +303,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, OnInit, AfterVie
 	}
 
 	private get _isTypeahead() {
-		return this.typeahead && this.typeahead.observers.length > 0;
+		return this.typeahead && this.typeahead.observed;
 	}
 
 	private get _validTerm() {


### PR DESCRIPTION
Implement proposed in [this](https://github.com/ng-select/ng-select/issues/2587) issue changes