### PR TITLE
fix: do not consider touchstart event as outside click

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -19,7 +19,7 @@ import {
 	viewChild,
 } from '@angular/core';
 
-import { animationFrameScheduler, asapScheduler, fromEvent, merge, Subject } from 'rxjs';
+import { animationFrameScheduler, asapScheduler, fromEvent, Subject } from 'rxjs';
 import { auditTime, takeUntil } from 'rxjs/operators';
 import { NgDropdownPanelService, PanelDimensions } from './ng-dropdown-panel.service';
 
@@ -231,7 +231,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 		}
 
 		this._zone.runOutsideAngular(() => {
-			merge(fromEvent(this._document, 'touchstart', { capture: true }), fromEvent(this._document, 'click', { capture: true }))
+			fromEvent(this._document, 'click', { capture: true })
 				.pipe(takeUntil(this._destroy$))
 				.subscribe(($event) => this._checkToClose($event));
 		});

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2399,15 +2399,6 @@ describe('NgSelectComponent', () => {
 			expect(fixture.componentInstance.select().isOpen()).toBeFalsy();
 		}));
 
-		it('should close dropdown if opened and touched outside dropdown container', fakeAsync(() => {
-			triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
-			expect(fixture.componentInstance.select().isOpen()).toBeTruthy();
-			const event = new TouchEvent('touchstart', { bubbles: true });
-			document.getElementById('outside').dispatchEvent(event);
-			tickAndDetectChanges(fixture);
-			expect(fixture.componentInstance.select().isOpen()).toBeFalsy();
-		}));
-
 		it('should prevent dropdown close if clicked on select', fakeAsync(() => {
 			triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
 			expect(select.isOpen()).toBeTruthy();


### PR DESCRIPTION
`touchstart` events were considered as outside clicks, which caused the dropdown to be closed when scrolling outside the select component on mobile devices. `click` events are sufficient to detect outside clicks on mobile devices. Tapping outside the select component still closes the dropdown.

Reverts #737. Fixes #2594.