### PR TITLE
Restore programmatic configurability by replacing readonly input signals with writable signals

### DIFF
--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -42,11 +42,11 @@ export class ItemsList {
 	}
 
 	get noItemsToSelect(): boolean {
-		return this._ngSelect.hideSelected() && this._items.length === this.selectedItems.length;
+		return this._ngSelect.hideSelectedState() && this._items.length === this.selectedItems.length;
 	}
 
 	get maxItemsSelected(): boolean {
-		return this._ngSelect.multiple() && this._ngSelect.maxSelectedItems() <= this.selectedItems.length;
+		return this._ngSelect.multipleState() && this._ngSelect.maxSelectedItemsState() <= this.selectedItems.length;
 	}
 
 	get lastSelectedItem() {
@@ -62,7 +62,7 @@ export class ItemsList {
 
 	setItems(items: readonly any[]) {
 		this._items = items.map((item, index) => this.mapItem(item, index));
-		const groupBy = this._ngSelect.groupBy();
+		const groupBy = this._ngSelect.groupByState();
 		if (groupBy) {
 			this._groups = this._groupBy(this._items, groupBy);
 			this._items = this._flatten(this._groups);
@@ -77,13 +77,13 @@ export class ItemsList {
 		if (item.selected || this.maxItemsSelected) {
 			return;
 		}
-		const multiple = this._ngSelect.multiple();
+		const multiple = this._ngSelect.multipleState();
 		if (!multiple) {
 			this.clearSelected();
 		}
 
-		this._selectionModel.select(item, multiple, this._ngSelect.selectableGroupAsModel());
-		if (this._ngSelect.hideSelected()) {
+		this._selectionModel.select(item, multiple, this._ngSelect.selectableGroupAsModelState());
+		if (this._ngSelect.hideSelectedState()) {
 			this._hideSelected(item);
 		}
 	}
@@ -92,17 +92,17 @@ export class ItemsList {
 		if (!item.selected) {
 			return;
 		}
-		const multiple = this._ngSelect.multiple();
+		const multiple = this._ngSelect.multipleState();
 		this._selectionModel.unselect(item, multiple);
-		if (this._ngSelect.hideSelected() && isDefined(item.index) && multiple) {
+		if (this._ngSelect.hideSelectedState() && isDefined(item.index) && multiple) {
 			this._showSelected(item);
 		}
 	}
 
 	findItem(value: any): NgOption {
 		let findBy: (item: NgOption) => boolean;
-		if (this._ngSelect.compareWith()) {
-			findBy = (item) => this._ngSelect.compareWith()(item.value, value);
+		if (this._ngSelect.compareWithState()) {
+			findBy = (item) => this._ngSelect.compareWithState()(item.value, value);
 		} else if (this._ngSelect.bindValue()) {
 			findBy = (item) => !item.children && this.resolveNested(item.value, this._ngSelect.bindValue()) === value;
 		} else {
@@ -125,7 +125,7 @@ export class ItemsList {
 			item.selected = keepDisabled && item.selected && item.disabled;
 			item.marked = false;
 		});
-		if (this._ngSelect.hideSelected()) {
+		if (this._ngSelect.hideSelectedState()) {
 			this.resetFilteredItems();
 		}
 	}
@@ -145,9 +145,9 @@ export class ItemsList {
 		}
 
 		this._filteredItems = [];
-		term = this._ngSelect.searchFn() ? term : searchHelper.stripSpecialChars(term).toLocaleLowerCase();
-		const match = this._ngSelect.searchFn() || this._defaultSearchFn;
-		const hideSelected = this._ngSelect.hideSelected();
+		term = this._ngSelect.searchFnState() ? term : searchHelper.stripSpecialChars(term).toLocaleLowerCase();
+		const match = this._ngSelect.searchFnState() || this._defaultSearchFn;
+		const hideSelected = this._ngSelect.hideSelectedState();
 
 		for (const key of Array.from(this._groups.keys())) {
 			const matchedItems = [];
@@ -155,7 +155,7 @@ export class ItemsList {
 				if (hideSelected && ((item.parent && item.parent.selected) || item.selected)) {
 					continue;
 				}
-				const searchItem = this._ngSelect.searchFn() ? item.value : item;
+				const searchItem = this._ngSelect.searchFnState() ? item.value : item;
 				if (match(term, searchItem)) {
 					matchedItems.push(item);
 				}
@@ -176,7 +176,7 @@ export class ItemsList {
 			return;
 		}
 
-		if (this._ngSelect.hideSelected() && this.selectedItems.length > 0) {
+		if (this._ngSelect.hideSelectedState() && this.selectedItems.length > 0) {
 			this._filteredItems = this._items.filter((x) => !x.selected);
 		} else {
 			this._filteredItems = this._items;
@@ -246,25 +246,25 @@ export class ItemsList {
 	}
 
 	mapSelectedItems() {
-		const multiple = this._ngSelect.multiple();
+		const multiple = this._ngSelect.multipleState();
 		for (const selected of this.selectedItems) {
 			const bindValue = this._ngSelect.bindValue();
 			let item: NgOption | null = null;
 
 			// When compareWith is used, we need to find the item using the original selected value rather than the extracted bindValue,
 			// since compareWith expects to compare against the original value
-			if (this._ngSelect.compareWith()) {
-				item = this._items.find((item) => this._ngSelect.compareWith()(item.value, selected.value));
+			if (this._ngSelect.compareWithState()) {
+				item = this._items.find((item) => this._ngSelect.compareWithState()(item.value, selected.value));
 			} else {
 				const value = bindValue ? this.resolveNested(selected.value, bindValue) : selected.value;
 				item = isDefined(value) ? this.findItem(value) : null;
 			}
 
 			this._selectionModel.unselect(selected, multiple);
-			this._selectionModel.select(item || selected, multiple, this._ngSelect.selectableGroupAsModel());
+			this._selectionModel.select(item || selected, multiple, this._ngSelect.selectableGroupAsModelState());
 		}
 
-		if (this._ngSelect.hideSelected()) {
+		if (this._ngSelect.hideSelectedState()) {
 			this._filteredItems = this.filteredItems.filter((x) => this.selectedItems.indexOf(x) === -1);
 		}
 	}
@@ -322,7 +322,7 @@ export class ItemsList {
 	}
 
 	private _getLastMarkedIndex() {
-		if (this._ngSelect.hideSelected()) {
+		if (this._ngSelect.hideSelectedState()) {
 			return -1;
 		}
 
@@ -353,7 +353,7 @@ export class ItemsList {
 			return groups;
 		}
 
-		const isFnKey = isFunction(this._ngSelect.groupBy());
+		const isFnKey = isFunction(this._ngSelect.groupByState());
 		const keyFn = (item: NgOption) => {
 			const key = isFnKey ? (<(value: any) => any>prop)(item.value) : item.value[<string>prop];
 			return isDefined(key) ? key : undefined;
@@ -373,7 +373,7 @@ export class ItemsList {
 	}
 
 	private _flatten(groups: OptionGroups) {
-		const isGroupByFn = isFunction(this._ngSelect.groupBy());
+		const isGroupByFn = isFunction(this._ngSelect.groupByState());
 		const items = [];
 		for (const key of Array.from(groups.keys())) {
 			let i = items.length;
@@ -394,12 +394,12 @@ export class ItemsList {
 				children: undefined,
 				parent: null,
 				index: i++,
-				disabled: !this._ngSelect.selectableGroup(),
+				disabled: !this._ngSelect.selectableGroupState(),
 				htmlId: newId(),
 			};
-			const groupKey = isGroupByFn ? this._ngSelect.bindLabel() : <string>this._ngSelect.groupBy();
+			const groupKey = isGroupByFn ? this._ngSelect.bindLabel() : <string>this._ngSelect.groupByState();
 			const groupValue =
-				this._ngSelect.groupValue() ||
+				this._ngSelect.groupValueState() ||
 				(() => {
 					if (isObjectKey) {
 						return (<NgOption>key).value;

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -4,14 +4,14 @@
 	[class.ng-has-value]="hasValue"
 	class="ng-select-container">
 	<div class="ng-value-container">
-		@if ((selectedItems.length === 0 && !searchTerm) || (fixedPlaceholder() ?? config.fixedPlaceholder)) {
+		@if ((selectedItems.length === 0 && !searchTerm) || (fixedPlaceholderState() ?? config.fixedPlaceholder)) {
 			<ng-template #defaultPlaceholderTemplate>
 				<div class="ng-placeholder">{{ placeholder() ?? config.placeholder }}</div>
 			</ng-template>
 			<ng-template [ngTemplateOutlet]="placeholderTemplate() || defaultPlaceholderTemplate"> </ng-template>
 		}
 
-		@if ((!multiLabelTemplate() || !multiple()) && selectedItems.length > 0) {
+		@if ((!multiLabelTemplate() || !multipleState()) && selectedItems.length > 0) {
 			@for (item of selectedItems; track trackByOption($index, item)) {
 				<div [class.ng-value-disabled]="item.disabled" class="ng-value">
 					<ng-template #defaultLabelTemplate>
@@ -26,7 +26,7 @@
 			}
 		}
 
-		@if (multiple() && multiLabelTemplate() && selectedValues.length > 0) {
+		@if (multipleState() && multiLabelTemplate() && selectedValues.length > 0) {
 			<ng-template [ngTemplateOutlet]="multiLabelTemplate()" [ngTemplateOutletContext]="{ items: selectedValues, clear: clearItem }">
 			</ng-template>
 		}
@@ -43,18 +43,18 @@
 				[attr.aria-activedescendant]="isOpen() ? itemsList?.markedItem?.htmlId : null"
 				[attr.aria-controls]="isOpen() ? dropdownId : null"
 				[attr.aria-expanded]="isOpen()"
-				[attr.aria-label]="ariaLabel()"
-				[attr.id]="labelForId()"
-				[attr.tabindex]="tabIndex()"
+				[attr.aria-label]="ariaLabelState()"
+				[attr.id]="labelForIdState()"
+				[attr.tabindex]="tabIndexState()"
 				[disabled]="disabled()"
-				[readOnly]="!searchable() || itemsList.maxItemsSelected"
+				[readOnly]="!searchableState() || itemsList.maxItemsSelected"
 				[value]="searchTerm ?? ''"
 				aria-autocomplete="list"
 				role="combobox" />
 		</div>
 	</div>
 
-	@if (loading()) {
+	@if (loadingState()) {
 		<ng-template #defaultLoadingSpinnerTemplate>
 			<div class="ng-spinner-loader"></div>
 		</ng-template>
@@ -84,13 +84,13 @@
 </div>
 
 @if (isOpen()) {
-	@let appendToValue = appendTo() || config.appendTo;
+	@let appendToValue = appendToState() || config.appendTo;
 	<ng-dropdown-panel
 		class="ng-dropdown-panel"
-		[virtualScroll]="virtualScroll() ?? !config.disableVirtualScroll ?? false"
-		[bufferAmount]="bufferAmount()"
+		[virtualScroll]="virtualScrollState() ?? !config.disableVirtualScroll ?? false"
+		[bufferAmount]="bufferAmountState()"
 		[appendTo]="appendToValue"
-		[position]="dropdownPosition()"
+		[position]="dropdownPositionState()"
 		[outsideClickEvent]="outsideClickEvent()"
 		[headerTemplate]="headerTemplate()"
 		[footerTemplate]="footerTemplate()"
@@ -102,10 +102,10 @@
 		(scroll)="scroll.emit($event)"
 		(scrollToEnd)="scrollToEnd.emit($event)"
 		(outsideClick)="close()"
-		[class.ng-select-multiple]="multiple()"
+		[class.ng-select-multiple]="multipleState()"
 		[class]="appendToValue ? (ngClass() ? ngClass() : classes) : null"
 		[id]="dropdownId"
-		[ariaLabelDropdown]="ariaLabelDropdown()">
+		[ariaLabelDropdown]="ariaLabelDropdownState()">
 		<ng-container>
 			@for (item of viewPortItems; track trackByOption($index, item)) {
 				<!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus, @angular-eslint/template/mouse-events-have-key-events -->

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -6,7 +6,7 @@
 	<div class="ng-value-container">
 		@if ((selectedItems.length === 0 && !searchTerm) || (fixedPlaceholderState() ?? config.fixedPlaceholder)) {
 			<ng-template #defaultPlaceholderTemplate>
-				<div class="ng-placeholder">{{ placeholder() ?? config.placeholder }}</div>
+				<div class="ng-placeholder">{{ placeholderState() ?? config.placeholder }}</div>
 			</ng-template>
 			<ng-template [ngTemplateOutlet]="placeholderTemplate() || defaultPlaceholderTemplate"> </ng-template>
 		}
@@ -70,7 +70,7 @@
 				role="button"
 				tabindex="0"
 				[attr.tabindex]="tabFocusOnClear() ? 0 : -1"
-				title="{{ clearAllText() || config.clearAllText }}"
+				title="{{ clearAllTextState() || config.clearAllText }}"
 				#clearButton
 				(click)="handleClearClick($event)">
 				<span class="ng-clear" aria-hidden="true">×</span>
@@ -91,7 +91,7 @@
 		[bufferAmount]="bufferAmountState()"
 		[appendTo]="appendToValue"
 		[position]="dropdownPositionState()"
-		[outsideClickEvent]="outsideClickEvent()"
+		[outsideClickEvent]="outsideClickEventState()"
 		[headerTemplate]="headerTemplate()"
 		[footerTemplate]="footerTemplate()"
 		[filterValue]="searchTerm"
@@ -103,7 +103,7 @@
 		(scrollToEnd)="scrollToEnd.emit($event)"
 		(outsideClick)="close()"
 		[class.ng-select-multiple]="multipleState()"
-		[class]="appendToValue ? (ngClass() ? ngClass() : classes) : null"
+		[class]="appendToValue ? (ngClassState() ? ngClassState() : classes) : null"
 		[id]="dropdownId"
 		[ariaLabelDropdown]="ariaLabelDropdownState()">
 		<ng-container>
@@ -146,7 +146,7 @@
 					(click)="selectTag()">
 					<ng-template #defaultTagTemplate>
 						<span
-							><span class="ng-tag-label">{{ addTagText() || config.addTagText }}</span
+							><span class="ng-tag-label">{{ addTagTextState() || config.addTagText }}</span
 							>"{{ searchTerm }}"</span
 						>
 					</ng-template>
@@ -159,7 +159,7 @@
 		</ng-container>
 		@if (showNoItemsFound()) {
 			<ng-template #defaultNotFoundTemplate>
-				<div class="ng-option ng-option-disabled">{{ notFoundText() ?? config.notFoundText }}</div>
+				<div class="ng-option ng-option-disabled">{{ notFoundTextState() ?? config.notFoundText }}</div>
 			</ng-template>
 			<ng-template
 				[ngTemplateOutlet]="notFoundTemplate() || defaultNotFoundTemplate"
@@ -168,13 +168,13 @@
 		}
 		@if (showTypeToSearch()) {
 			<ng-template #defaultTypeToSearchTemplate>
-				<div class="ng-option ng-option-disabled">{{ typeToSearchText() || config.typeToSearchText }}</div>
+				<div class="ng-option ng-option-disabled">{{ typeToSearchTextState() || config.typeToSearchText }}</div>
 			</ng-template>
 			<ng-template [ngTemplateOutlet]="typeToSearchTemplate() || defaultTypeToSearchTemplate"></ng-template>
 		}
-		@if (loading() && itemsList.filteredItems.length === 0) {
+		@if (loadingState() && itemsList.filteredItems.length === 0) {
 			<ng-template #defaultLoadingTextTemplate>
-				<div class="ng-option ng-option-disabled">{{ loadingText() || config.loadingText }}</div>
+				<div class="ng-option ng-option-disabled">{{ loadingTextState() || config.loadingText }}</div>
 			</ng-template>
 			<ng-template
 				[ngTemplateOutlet]="loadingTextTemplate() || defaultLoadingTextTemplate"
@@ -187,6 +187,6 @@
 <!-- Always present aria-live region -->
 <div aria-atomic="true" aria-live="polite" class="ng-visually-hidden" role="status">
 	@if (isOpen() && showNoItemsFound()) {
-		{{ notFoundText() ?? config.notFoundText }}
+		{{ notFoundTextState() ?? config.notFoundText }}
 	}
 </div>

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2441,7 +2441,7 @@ describe('NgSelectComponent', () => {
 
 			const selectClasses = (<HTMLElement>fixture.nativeElement).querySelector('.ng-select').classList;
 			const panelClasses = (<HTMLElement>fixture.nativeElement).querySelector('.ng-dropdown-panel').classList;
-			expect(select.dropdownPosition()).toBe('auto');
+			expect(select.dropdownPositionState()).toBe('auto');
 			expect(selectClasses.contains('ng-select-bottom')).toBeTruthy();
 			expect(panelClasses.contains('ng-select-bottom')).toBeTruthy();
 			expect(selectClasses.contains('ng-select-top')).toBeFalsy();
@@ -2457,7 +2457,7 @@ describe('NgSelectComponent', () => {
 
 			const selectClasses = (<HTMLElement>fixture.nativeElement).querySelector('.ng-select').classList;
 			const panelClasses = (<HTMLElement>fixture.nativeElement).querySelector('.ng-dropdown-panel').classList;
-			expect(select.dropdownPosition()).toBe('top');
+			expect(select.dropdownPositionState()).toBe('top');
 			expect(selectClasses.contains('ng-select-bottom')).toBeFalsy();
 			expect(panelClasses.contains('ng-select-bottom')).toBeFalsy();
 			expect(selectClasses.contains('ng-select-top')).toBeTruthy();
@@ -2473,7 +2473,7 @@ describe('NgSelectComponent', () => {
 
 			const selectClasses = (<HTMLElement>fixture.nativeElement).querySelector('.ng-select').classList;
 			const panelClasses = document.querySelector('.ng-dropdown-panel').classList;
-			expect(select.dropdownPosition()).toBe('auto');
+			expect(select.dropdownPositionState()).toBe('auto');
 			expect(selectClasses.contains('ng-select-bottom')).toBeTruthy();
 			expect(panelClasses.contains('ng-select-bottom')).toBeTruthy();
 			expect(selectClasses.contains('ng-select-top')).toBeFalsy();
@@ -3012,7 +3012,7 @@ describe('NgSelectComponent', () => {
 				fixture.componentInstance.addTag = true;
 				fixture.componentInstance.typeahead = new Subject();
 				tickAndDetectChanges(fixture);
-				select.typeahead().subscribe();
+				select.typeaheadState().subscribe();
 				fixture.componentInstance.cities = [];
 				tickAndDetectChanges(fixture);
 				fixture.componentInstance.select().filter('New item');
@@ -3944,7 +3944,7 @@ describe('NgSelectComponent', () => {
 				);
 
 				expect(fixture.componentInstance.select().clearSearchOnAddValue()).toBeFalsy();
-				expect(fixture.componentInstance.select().closeOnSelect()).toBeFalsy();
+				expect(fixture.componentInstance.select().closeOnSelectState()).toBeFalsy();
 
 				fixture.componentInstance.filter.subscribe();
 				const select = fixture.componentInstance.select();
@@ -3972,7 +3972,7 @@ describe('NgSelectComponent', () => {
 				);
 
 				expect(fixture.componentInstance.select().clearSearchOnAddValue()).toBeTruthy();
-				expect(fixture.componentInstance.select().closeOnSelect()).toBeFalsy();
+				expect(fixture.componentInstance.select().closeOnSelectState()).toBeFalsy();
 
 				let lastEmittedSearchTerm = '';
 				fixture.componentInstance.filter.subscribe((value) => {
@@ -4059,7 +4059,7 @@ describe('NgSelectComponent', () => {
                         [(ngModel)]="selectedCity">
                     </ng-select>`,
 				);
-				expect(fixture.componentInstance.select().editableSearchTerm()).toBeTruthy();
+				expect(fixture.componentInstance.select().editableSearchTermState()).toBeTruthy();
 				const select = fixture.componentInstance.select();
 				const input = select.searchInput().nativeElement;
 				const selectedCity = fixture.componentInstance.cities[0];
@@ -4235,7 +4235,7 @@ describe('NgSelectComponent', () => {
 			select.filter('not-in-list');
 			tickAndDetectChanges(fixture);
 
-			const notFoundText = fixture.componentInstance.select().notFoundText();
+			const notFoundText = fixture.componentInstance.select().notFoundTextState();
 			expect(notFoundText).toBe('No items found (aria-live)');
 		}));
 	});

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -17,6 +17,7 @@ import {
 	InjectionToken,
 	Injector,
 	input,
+	Input,
 	model,
 	numberAttribute,
 	OnChanges,
@@ -106,60 +107,141 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	// signals
 	public readonly _disabled = signal<boolean>(false);
 	// inputs
-	readonly ariaLabelDropdown = input<string>('Options List');
-	readonly ariaLabel = input<string | undefined>(undefined);
-	readonly markFirst = input(true, { transform: booleanAttribute });
-	readonly placeholder = input<string>(this.config.placeholder);
-	readonly fixedPlaceholder = input<boolean>(true);
-	readonly notFoundText = input<string>(undefined);
-	readonly typeToSearchText = input<string>(undefined);
-	readonly preventToggleOnRightClick = input<boolean>(false);
-	readonly addTagText = input<string>(undefined);
-	readonly loadingText = input<string>(undefined);
-	readonly clearAllText = input<string>(undefined);
-	readonly dropdownPosition = input<DropdownPosition>('auto');
-	readonly appendTo = input<string>(undefined);
-	readonly outsideClickEvent = input<'click' | 'mousedown'>(this.config.outsideClickEvent);
-	readonly loading = input(false, { transform: booleanAttribute });
-	readonly closeOnSelect = input(true, { transform: booleanAttribute });
-	readonly hideSelected = input(false, { transform: booleanAttribute });
-	readonly selectOnTab = input(false, { transform: booleanAttribute });
-	readonly openOnEnter = input(undefined, { transform: booleanAttribute });
-	readonly maxSelectedItems = input<number, unknown>(undefined, { transform: numberAttribute });
-	readonly groupBy = input<string | ((value: any) => any)>(undefined);
-	readonly groupValue = input<GroupValueFn>(undefined);
-	readonly bufferAmount = input(4, { transform: numberAttribute });
-	readonly virtualScroll = input<boolean, unknown>(undefined, { transform: booleanAttribute });
-	readonly selectableGroup = input(false, { transform: booleanAttribute });
-	readonly tabFocusOnClearButton = input<boolean | undefined>();
-	readonly selectableGroupAsModel = input(true, { transform: booleanAttribute });
-	readonly searchFn = input(null);
-	readonly trackByFn = input(null);
-	readonly clearOnBackspace = input(true, { transform: booleanAttribute });
-	readonly labelForId = input(null);
-	readonly inputAttrs = input<Record<string, string>>({});
-	readonly tabIndex = input<number, unknown>(undefined, { transform: numberAttribute });
-	readonly readonly = input(false, { transform: booleanAttribute });
-	readonly searchWhileComposing = input(true, { transform: booleanAttribute });
-	readonly minTermLength = input(0, { transform: numberAttribute });
-	readonly editableSearchTerm = input(false, { transform: booleanAttribute });
-	readonly ngClass = input(null);
-	readonly typeahead = input<Subject<string>>(undefined);
-	readonly multiple = input(false, { transform: booleanAttribute });
-	readonly addTag = input<boolean | AddTagFn>(false);
-	readonly searchable = input(true, { transform: booleanAttribute });
-	readonly clearable = input(true, { transform: booleanAttribute });
-	readonly deselectOnClick = input<boolean>();
-	readonly clearSearchOnAdd = input(undefined);
-	readonly compareWith = input(undefined, {
-		transform: (fn: CompareWithFn | undefined) => {
-			if (fn !== undefined && fn !== null && !isFunction(fn)) {
-				throw Error('`compareWith` must be a function.');
-			}
-			return fn;
-		},
-	});
-	readonly keyDownFn = input<(_: KeyboardEvent) => boolean>((_: KeyboardEvent) => true);
+	readonly ariaLabelDropdown = model<string>('Options List');
+	readonly ariaLabel = model<string | undefined>(undefined);
+	readonly markFirst = model<boolean>(true);
+	readonly placeholder = model<string>(this.config.placeholder);
+	readonly fixedPlaceholder = model<boolean>(true);
+	readonly notFoundText = model<string>(undefined);
+	readonly typeToSearchText = model<string>(undefined);
+	readonly preventToggleOnRightClick = model<boolean>(false);
+	readonly addTagText = model<string>(undefined);
+	readonly loadingText = model<string>(undefined);
+	readonly clearAllText = model<string>(undefined);
+	readonly dropdownPosition = model<DropdownPosition>('auto');
+	readonly appendTo = model<string>(undefined);
+	readonly outsideClickEvent = model<'click' | 'mousedown'>(this.config.outsideClickEvent);
+	readonly loading = model<boolean>(false);
+	readonly closeOnSelect = model<boolean>(true);
+	readonly hideSelected = model<boolean>(false);
+	readonly selectOnTab = model<boolean>(false);
+	readonly openOnEnter = model<boolean | undefined>(undefined);
+	readonly maxSelectedItems = model<number | undefined>(undefined);
+	readonly groupBy = model<string | ((value: any) => any)>(undefined);
+	readonly groupValue = model<GroupValueFn>(undefined);
+	readonly bufferAmount = model<number>(4);
+	readonly virtualScroll = model<boolean | undefined>(undefined);
+	readonly selectableGroup = model<boolean>(false);
+	readonly tabFocusOnClearButton = model<boolean | undefined>(undefined);
+	readonly selectableGroupAsModel = model<boolean>(true);
+	readonly searchFn = model<any>(null);
+	readonly trackByFn = model<any>(null);
+	readonly clearOnBackspace = model<boolean>(true);
+	readonly labelForId = model<any>(null);
+	readonly inputAttrs = model<Record<string, string>>({});
+	readonly tabIndex = model<number | undefined>(undefined);
+	readonly readonly = model<boolean>(false);
+	readonly searchWhileComposing = model<boolean>(true);
+	readonly minTermLength = model<number>(0);
+	readonly editableSearchTerm = model<boolean>(false);
+	readonly ngClass = model<any>(null);
+	readonly typeahead = model<Subject<string> | undefined>(undefined);
+	readonly multiple = model<boolean>(false);
+	readonly addTag = model<boolean | AddTagFn>(false);
+	readonly searchable = model<boolean>(true);
+	readonly clearable = model<boolean>(true);
+	readonly deselectOnClick = model<boolean | undefined>(undefined);
+	readonly clearSearchOnAdd = model<any | undefined>(undefined);
+	readonly compareWith = model<CompareWithFn | undefined>(undefined);
+	readonly keyDownFn = model<(_: KeyboardEvent) => boolean>((_: KeyboardEvent) => true);
+
+	// @Input setters that need to apply transforms/validation
+	@Input('markFirst') set markFirstInput(v: any) {
+		this.markFirst.set(booleanAttribute(v));
+	}
+
+	@Input('loading') set loadingInput(v: any) {
+		this.loading.set(booleanAttribute(v));
+	}
+
+	@Input('closeOnSelect') set closeOnSelectInput(v: any) {
+		this.closeOnSelect.set(booleanAttribute(v));
+	}
+
+	@Input('hideSelected') set hideSelectedInput(v: any) {
+		this.hideSelected.set(booleanAttribute(v));
+	}
+
+	@Input('selectOnTab') set selectOnTabInput(v: any) {
+		this.selectOnTab.set(booleanAttribute(v));
+	}
+
+	@Input('openOnEnter') set openOnEnterInput(v: any) {
+		this.openOnEnter.set(booleanAttribute(v));
+	}
+
+	@Input('maxSelectedItems') set maxSelectedItemsInput(v: any) {
+		this.maxSelectedItems.set(numberAttribute(v));
+	}
+
+	@Input('bufferAmount') set bufferAmountInput(v: any) {
+		this.bufferAmount.set(numberAttribute(v));
+	}
+
+	@Input('virtualScroll') set virtualScrollInput(v: any) {
+		this.virtualScroll.set(booleanAttribute(v));
+	}
+
+	@Input('selectableGroup') set selectableGroupInput(v: any) {
+		this.selectableGroup.set(booleanAttribute(v));
+	}
+
+	@Input('selectableGroupAsModel') set selectableGroupAsModelInput(v: any) {
+		this.selectableGroupAsModel.set(booleanAttribute(v));
+	}
+
+	@Input('clearOnBackspace') set clearOnBackspaceInput(v: any) {
+		this.clearOnBackspace.set(booleanAttribute(v));
+	}
+
+	@Input('tabIndex') set tabIndexInput(v: any) {
+		this.tabIndex.set(numberAttribute(v));
+	}
+
+	@Input('readonly') set readonlyInput(v: any) {
+		this.readonly.set(booleanAttribute(v));
+	}
+
+	@Input('searchWhileComposing') set searchWhileComposingInput(v: any) {
+		this.searchWhileComposing.set(booleanAttribute(v));
+	}
+
+	@Input('minTermLength') set minTermLengthInput(v: any) {
+		this.minTermLength.set(numberAttribute(v));
+	}
+
+	@Input('editableSearchTerm') set editableSearchTermInput(v: any) {
+		this.editableSearchTerm.set(booleanAttribute(v));
+	}
+
+	@Input('multiple') set multipleInput(v: any) {
+		this.multiple.set(booleanAttribute(v));
+	}
+
+	@Input('searchable') set searchableInput(v: any) {
+		this.searchable.set(booleanAttribute(v));
+	}
+
+	@Input('clearable') set clearableInput(v: any) {
+		this.clearable.set(booleanAttribute(v));
+	}
+
+	@Input('compareWith') set compareWithInput(fn: CompareWithFn | undefined) {
+		if (fn !== undefined && fn !== null && !isFunction(fn)) {
+			throw Error('`compareWith` must be a function.');
+		}
+		this.compareWith.set(fn);
+	}
 
 	// models
 	readonly bindLabel = model<string>(undefined);

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -17,7 +17,6 @@ import {
 	InjectionToken,
 	Injector,
 	input,
-	Input,
 	model,
 	numberAttribute,
 	OnChanges,
@@ -106,150 +105,68 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 	// signals
 	public readonly _disabled = signal<boolean>(false);
-	readonly markFirst = signal<boolean>(true);
-	readonly loading = signal<boolean>(false);
-	readonly closeOnSelect = signal<boolean>(true);
-	readonly hideSelected = signal<boolean>(false);
-	readonly selectOnTab = signal<boolean>(false);
-	readonly openOnEnter = signal<boolean | undefined>(undefined);
-	readonly maxSelectedItems = signal<number | undefined>(undefined);
-	readonly bufferAmount = signal<number>(4);
-	readonly virtualScroll = signal<boolean | undefined>(undefined);
-	readonly selectableGroup = signal<boolean>(false);
-	readonly selectableGroupAsModel = signal<boolean>(true);
-	readonly clearOnBackspace = signal<boolean>(true);
-	readonly tabIndex = signal<number | undefined>(undefined);
-	readonly readonly = signal<boolean>(false);
-	readonly searchWhileComposing = signal<boolean>(true);
-	readonly minTermLength = signal<number>(0);
-	readonly editableSearchTerm = signal<boolean>(false);
-	readonly multiple = signal<boolean>(false);
-	readonly searchable = signal<boolean>(true);
-	readonly clearable = signal<boolean>(true);
-	readonly compareWith = signal<CompareWithFn | undefined>(undefined);
+	// inputs
+	readonly ariaLabelDropdown = input<string>('Options List');
+	readonly ariaLabel = input<string | undefined>(undefined);
+	readonly markFirst = input(true, { transform: booleanAttribute });
+	readonly placeholder = input<string>(this.config.placeholder);
+	readonly fixedPlaceholder = input<boolean>(true);
+	readonly notFoundText = input<string>(undefined);
+	readonly typeToSearchText = input<string>(undefined);
+	readonly preventToggleOnRightClick = input<boolean>(false);
+	readonly addTagText = input<string>(undefined);
+	readonly loadingText = input<string>(undefined);
+	readonly clearAllText = input<string>(undefined);
+	readonly dropdownPosition = input<DropdownPosition>('auto');
+	readonly appendTo = input<string>(undefined);
+	readonly outsideClickEvent = input<'click' | 'mousedown'>(this.config.outsideClickEvent);
+	readonly loading = input(false, { transform: booleanAttribute });
+	readonly closeOnSelect = input(true, { transform: booleanAttribute });
+	readonly hideSelected = input(false, { transform: booleanAttribute });
+	readonly selectOnTab = input(false, { transform: booleanAttribute });
+	readonly openOnEnter = input(undefined, { transform: booleanAttribute });
+	readonly maxSelectedItems = input<number, unknown>(undefined, { transform: numberAttribute });
+	readonly groupBy = input<string | ((value: any) => any)>(undefined);
+	readonly groupValue = input<GroupValueFn>(undefined);
+	readonly bufferAmount = input(4, { transform: numberAttribute });
+	readonly virtualScroll = input<boolean, unknown>(undefined, { transform: booleanAttribute });
+	readonly selectableGroup = input(false, { transform: booleanAttribute });
+	readonly tabFocusOnClearButton = input<boolean | undefined>();
+	readonly selectableGroupAsModel = input(true, { transform: booleanAttribute });
+	readonly searchFn = input(null);
+	readonly trackByFn = input(null);
+	readonly clearOnBackspace = input(true, { transform: booleanAttribute });
+	readonly labelForId = input(null);
+	readonly inputAttrs = input<Record<string, string>>({});
+	readonly tabIndex = input<number, unknown>(undefined, { transform: numberAttribute });
+	readonly readonly = input(false, { transform: booleanAttribute });
+	readonly searchWhileComposing = input(true, { transform: booleanAttribute });
+	readonly minTermLength = input(0, { transform: numberAttribute });
+	readonly editableSearchTerm = input(false, { transform: booleanAttribute });
+	readonly ngClass = input(null);
+	readonly typeahead = input<Subject<string>>(undefined);
+	readonly multiple = input(false, { transform: booleanAttribute });
+	readonly addTag = input<boolean | AddTagFn>(false);
+	readonly searchable = input(true, { transform: booleanAttribute });
+	readonly clearable = input(true, { transform: booleanAttribute });
+	readonly deselectOnClick = input<boolean>();
+	readonly clearSearchOnAdd = input(undefined);
+	readonly compareWith = input(undefined, {
+		transform: (fn: CompareWithFn | undefined) => {
+			if (fn !== undefined && fn !== null && !isFunction(fn)) {
+				throw Error('`compareWith` must be a function.');
+			}
+			return fn;
+		},
+	});
+	readonly keyDownFn = input<(_: KeyboardEvent) => boolean>((_: KeyboardEvent) => true);
 
 	// models
-	readonly ariaLabelDropdown = model<string>('Options List');
-	readonly ariaLabel = model<string | undefined>(undefined);
-	readonly placeholder = model<string>(this.config.placeholder);
-	readonly fixedPlaceholder = model<boolean>(true);
-	readonly notFoundText = model<string>(undefined);
-	readonly typeToSearchText = model<string>(undefined);
-	readonly preventToggleOnRightClick = model<boolean>(false);
-	readonly addTagText = model<string>(undefined);
-	readonly loadingText = model<string>(undefined);
-	readonly clearAllText = model<string>(undefined);
-	readonly dropdownPosition = model<DropdownPosition>('auto');
-	readonly appendTo = model<string>(undefined);
-	readonly outsideClickEvent = model<'click' | 'mousedown'>(this.config.outsideClickEvent);
-	readonly groupBy = model<string | ((value: any) => any)>(undefined);
-	readonly groupValue = model<GroupValueFn>(undefined);
-	readonly tabFocusOnClearButton = model<boolean | undefined>(undefined);
-	readonly searchFn = model<any>(null);
-	readonly trackByFn = model<any>(null);
-	readonly labelForId = model<any>(null);
-	readonly inputAttrs = model<Record<string, string>>({});
-	readonly ngClass = model<any>(null);
-	readonly typeahead = model<Subject<string> | undefined>(undefined);
-	readonly addTag = model<boolean | AddTagFn>(false);
-	readonly deselectOnClick = model<boolean | undefined>(undefined);
-	readonly clearSearchOnAdd = model<any | undefined>(undefined);
-	readonly keyDownFn = model<(_: KeyboardEvent) => boolean>((_: KeyboardEvent) => true);
 	readonly bindLabel = model<string>(undefined);
 	readonly bindValue = model<string>(undefined);
 	readonly appearance = model<string>(undefined);
 	readonly isOpen = model<boolean | undefined>(false);
 	readonly items = model<readonly any[]>([]);
-
-	// @Input setters that need to apply transforms/validation
-	/* eslint-disable @angular-eslint/no-input-rename */
-	@Input('markFirst') set markFirstInput(v: unknown) {
-		this.markFirst.set(booleanAttribute(v));
-	}
-
-	@Input('loading') set loadingInput(v: unknown) {
-		this.loading.set(booleanAttribute(v));
-	}
-
-	@Input('closeOnSelect') set closeOnSelectInput(v: unknown) {
-		this.closeOnSelect.set(booleanAttribute(v));
-	}
-
-	@Input('hideSelected') set hideSelectedInput(v: unknown) {
-		this.hideSelected.set(booleanAttribute(v));
-	}
-
-	@Input('selectOnTab') set selectOnTabInput(v: unknown) {
-		this.selectOnTab.set(booleanAttribute(v));
-	}
-
-	@Input('openOnEnter') set openOnEnterInput(v: unknown) {
-		this.openOnEnter.set(booleanAttribute(v));
-	}
-
-	@Input('maxSelectedItems') set maxSelectedItemsInput(v: unknown) {
-		this.maxSelectedItems.set(numberAttribute(v));
-	}
-
-	@Input('bufferAmount') set bufferAmountInput(v: unknown) {
-		this.bufferAmount.set(numberAttribute(v));
-	}
-
-	@Input('virtualScroll') set virtualScrollInput(v: unknown) {
-		this.virtualScroll.set(booleanAttribute(v));
-	}
-
-	@Input('selectableGroup') set selectableGroupInput(v: unknown) {
-		this.selectableGroup.set(booleanAttribute(v));
-	}
-
-	@Input('selectableGroupAsModel') set selectableGroupAsModelInput(v: unknown) {
-		this.selectableGroupAsModel.set(booleanAttribute(v));
-	}
-
-	@Input('clearOnBackspace') set clearOnBackspaceInput(v: unknown) {
-		this.clearOnBackspace.set(booleanAttribute(v));
-	}
-
-	@Input('tabIndex') set tabIndexInput(v: unknown) {
-		this.tabIndex.set(numberAttribute(v));
-	}
-
-	@Input('readonly') set readonlyInput(v: unknown) {
-		this.readonly.set(booleanAttribute(v));
-	}
-
-	@Input('searchWhileComposing') set searchWhileComposingInput(v: unknown) {
-		this.searchWhileComposing.set(booleanAttribute(v));
-	}
-
-	@Input('minTermLength') set minTermLengthInput(v: unknown) {
-		this.minTermLength.set(numberAttribute(v));
-	}
-
-	@Input('editableSearchTerm') set editableSearchTermInput(v: unknown) {
-		this.editableSearchTerm.set(booleanAttribute(v));
-	}
-
-	@Input('multiple') set multipleInput(v: unknown) {
-		this.multiple.set(booleanAttribute(v));
-	}
-
-	@Input('searchable') set searchableInput(v: unknown) {
-		this.searchable.set(booleanAttribute(v));
-	}
-
-	@Input('clearable') set clearableInput(v: unknown) {
-		this.clearable.set(booleanAttribute(v));
-	}
-
-	@Input('compareWith') set compareWithInput(fn: CompareWithFn | undefined) {
-		if (fn !== undefined && fn !== null && !isFunction(fn)) {
-			throw Error('`compareWith` must be a function.');
-		}
-		this.compareWith.set(fn);
-	}
-	/* eslint-enable @angular-eslint/no-input-rename */
 
 	// output events
 	readonly blurEvent = output<any>({ alias: 'blur' });

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -17,6 +17,7 @@ import {
 	InjectionToken,
 	Injector,
 	input,
+	linkedSignal,
 	model,
 	numberAttribute,
 	OnChanges,
@@ -85,12 +86,12 @@ export type GroupValueFn = (key: string | any, children: any[]) => string | any;
 	imports: [NgTemplateOutlet, NgItemLabelDirective, NgDropdownPanelComponent],
 	host: {
 		'[class.ng-select]': 'true',
-		'[class.ng-select-single]': '!multiple()',
-		'[class.ng-select-typeahead]': 'typeahead()',
-		'[class.ng-select-multiple]': 'multiple()',
-		'[class.ng-select-taggable]': 'addTag()',
-		'[class.ng-select-searchable]': 'searchable()',
-		'[class.ng-select-clearable]': 'clearable()',
+		'[class.ng-select-single]': '!multipleState()',
+		'[class.ng-select-typeahead]': 'typeaheadState()',
+		'[class.ng-select-multiple]': 'multipleState()',
+		'[class.ng-select-taggable]': 'addTagState()',
+		'[class.ng-select-searchable]': 'searchableState()',
+		'[class.ng-select-clearable]': 'clearableState()',
 		'[class.ng-select-opened]': 'isOpen()',
 		'[class.ng-select-filtered]': 'filtered',
 		'[class.ng-select-disabled]': 'disabled()',
@@ -105,6 +106,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 	// signals
 	public readonly _disabled = signal<boolean>(false);
+
 	// inputs
 	readonly ariaLabelDropdown = input<string>('Options List');
 	readonly ariaLabel = input<string | undefined>(undefined);
@@ -161,6 +163,55 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	});
 	readonly keyDownFn = input<(_: KeyboardEvent) => boolean>((_: KeyboardEvent) => true);
 
+	// writeable linked signals
+	readonly ariaLabelDropdownState = linkedSignal(() => this.ariaLabelDropdown());
+	readonly ariaLabelState = linkedSignal(() => this.ariaLabel());
+	readonly markFirstState = linkedSignal(() => this.markFirst());
+	readonly placeholderState = linkedSignal(() => this.placeholder());
+	readonly fixedPlaceholderState = linkedSignal(() => this.fixedPlaceholder());
+	readonly notFoundTextState = linkedSignal(() => this.notFoundText());
+	readonly typeToSearchTextState = linkedSignal(() => this.typeToSearchText());
+	readonly preventToggleOnRightClickState = linkedSignal(() => this.preventToggleOnRightClick());
+	readonly addTagTextState = linkedSignal(() => this.addTagText());
+	readonly loadingTextState = linkedSignal(() => this.loadingText());
+	readonly clearAllTextState = linkedSignal(() => this.clearAllText());
+	readonly dropdownPositionState = linkedSignal(() => this.dropdownPosition());
+	readonly appendToState = linkedSignal(() => this.appendTo());
+	readonly outsideClickEventState = linkedSignal(() => this.outsideClickEvent());
+	readonly loadingState = linkedSignal(() => this.loading());
+	readonly closeOnSelectState = linkedSignal(() => this.closeOnSelect());
+	readonly hideSelectedState = linkedSignal(() => this.hideSelected());
+	readonly selectOnTabState = linkedSignal(() => this.selectOnTab());
+	readonly openOnEnterState = linkedSignal(() => this.openOnEnter());
+	readonly maxSelectedItemsState = linkedSignal(() => this.maxSelectedItems());
+	readonly groupByState = linkedSignal(() => this.groupBy());
+	readonly groupValueState = linkedSignal(() => this.groupValue());
+	readonly bufferAmountState = linkedSignal(() => this.bufferAmount());
+	readonly virtualScrollState = linkedSignal(() => this.virtualScroll());
+	readonly selectableGroupState = linkedSignal(() => this.selectableGroup());
+	readonly tabFocusOnClearButtonState = linkedSignal(() => this.tabFocusOnClearButton());
+	readonly selectableGroupAsModelState = linkedSignal(() => this.selectableGroupAsModel());
+	readonly searchFnState = linkedSignal(() => this.searchFn());
+	readonly trackByFnState = linkedSignal(() => this.trackByFn());
+	readonly clearOnBackspaceState = linkedSignal(() => this.clearOnBackspace());
+	readonly labelForIdState = linkedSignal(() => this.labelForId());
+	readonly inputAttrsState = linkedSignal(() => this.inputAttrs());
+	readonly tabIndexState = linkedSignal(() => this.tabIndex());
+	readonly readonlyState = linkedSignal(() => this.readonly());
+	readonly searchWhileComposingState = linkedSignal(() => this.searchWhileComposing());
+	readonly minTermLengthState = linkedSignal(() => this.minTermLength());
+	readonly editableSearchTermState = linkedSignal(() => this.editableSearchTerm());
+	readonly ngClassState = linkedSignal(() => this.ngClass());
+	readonly typeaheadState = linkedSignal(() => this.typeahead());
+	readonly multipleState = linkedSignal(() => this.multiple());
+	readonly addTagState = linkedSignal(() => this.addTag());
+	readonly searchableState = linkedSignal(() => this.searchable());
+	readonly clearableState = linkedSignal(() => this.clearable());
+	readonly deselectOnClickState = linkedSignal(() => this.deselectOnClick());
+	readonly clearSearchOnAddState = linkedSignal(() => this.clearSearchOnAdd());
+	readonly compareWithState = linkedSignal(() => this.compareWith());
+	readonly keyDownFnState = linkedSignal(() => this.keyDownFn());
+
 	// models
 	readonly bindLabel = model<string>(undefined);
 	readonly bindValue = model<string>(undefined);
@@ -188,24 +239,24 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	readonly scrollToEnd = output<any>({ alias: 'scrollToEnd' });
 
 	// computed
-	readonly disabled = computed(() => this.readonly() || this._disabled());
+	readonly disabled = computed(() => this.readonlyState() || this._disabled());
 	readonly clearSearchOnAddValue = computed(() => {
-		if (isDefined(this.clearSearchOnAdd())) {
-			return this.clearSearchOnAdd();
+		if (isDefined(this.clearSearchOnAddState())) {
+			return this.clearSearchOnAddState();
 		}
 		if (isDefined(this.config.clearSearchOnAdd)) {
 			return this.config.clearSearchOnAdd;
 		}
-		return this.closeOnSelect();
+		return this.closeOnSelectState();
 	});
 	readonly deselectOnClickValue = computed(() => {
-		if (isDefined(this.deselectOnClick())) {
-			return this.deselectOnClick();
+		if (isDefined(this.deselectOnClickState())) {
+			return this.deselectOnClickState();
 		}
 		if (isDefined(this.config.deselectOnClick)) {
 			return this.config.deselectOnClick;
 		}
-		return this.multiple();
+		return this.multipleState();
 	});
 	// content child queries
 	readonly optionTemplate = contentChild(NgOptionTemplateDirective, { read: TemplateRef });
@@ -239,7 +290,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	private readonly autoFocus = inject(new HostAttributeToken('autofocus'), { optional: true });
 	// private variables
 	private readonly _defaultLabel = 'label';
-	private readonly _editableSearchTerm = computed(() => this.editableSearchTerm() && !this.multiple());
+	private readonly _editableSearchTerm = computed(() => this.editableSearchTermState() && !this.multipleState());
 	private _focused: boolean;
 	private _injector = inject(Injector);
 	private _isComposing = false;
@@ -251,7 +302,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	private readonly _searchTerm = signal<string>(null);
 	private readonly _validTerm = computed(() => {
 		const term = this._searchTerm()?.trim();
-		return term && term.length >= this.minTermLength();
+		return term && term.length >= this.minTermLengthState();
 	});
 
 	constructor() {
@@ -265,7 +316,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	get filtered() {
-		return (!!this.searchTerm && this.searchable()) || this._isComposing;
+		return (!!this.searchTerm && this.searchableState()) || this._isComposing;
 	}
 
 	get focused() {
@@ -302,10 +353,10 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 		const term = this.searchTerm.toLowerCase().trim();
 		return (
-			this.addTag() &&
+			this.addTagState() &&
 			!this.itemsList.filteredItems.some((x) => x.label.toLowerCase() === term) &&
-			((!this.hideSelected() && this.isOpen()) || !this.selectedItems.some((x) => x.label.toLowerCase() === term)) &&
-			!this.loading()
+			((!this.hideSelectedState() && this.isOpen()) || !this.selectedItems.some((x) => x.label.toLowerCase() === term)) &&
+			!this.loadingState()
 		);
 	}
 
@@ -356,7 +407,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	handleKeyDown($event: KeyboardEvent) {
 		const keyName = $event.key;
 		if (Object.values(KeyCode).includes(keyName as KeyCode)) {
-			if (this.keyDownFn()($event) === false) {
+			if (this.keyDownFnState()($event) === false) {
 				return;
 			}
 			this.handleKeyCode($event);
@@ -416,7 +467,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			return;
 		}
 
-		if (this.preventToggleOnRightClick() && $event.button === 2) {
+		if (this.preventToggleOnRightClickState() && $event.button === 2) {
 			return false;
 		}
 		const target = $event.target as HTMLElement;
@@ -442,7 +493,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			this.focus();
 		}
 
-		if (this.searchable()) {
+		if (this.searchableState()) {
 			this.open();
 		} else {
 			this.toggle();
@@ -470,7 +521,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	clearModel() {
-		if (!this.clearable()) {
+		if (!this.clearableState()) {
 			return;
 		}
 		this.itemsList.clearSelected();
@@ -512,11 +563,11 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			return;
 		}
 
-		if (!this.typeahead()?.observed && !this.addTag() && this.itemsList.noItemsToSelect) {
+		if (!this.typeaheadState()?.observed && !this.addTagState() && this.itemsList.noItemsToSelect) {
 			return;
 		}
 		this.isOpen.set(true);
-		this.itemsList.markSelectedOrDefault(this.markFirst());
+		this.itemsList.markSelectedOrDefault(this.markFirstState());
 		this.openEvent.emit();
 		if (!this.searchTerm) {
 			this.focus();
@@ -565,12 +616,12 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			}
 
 			this._updateNgModel();
-			if (this.multiple()) {
+			if (this.multipleState()) {
 				this.addEvent.emit(item.value);
 			}
 		}
 
-		if (this.closeOnSelect() || this.itemsList.noItemsToSelect) {
+		if (this.closeOnSelectState() || this.itemsList.noItemsToSelect) {
 			this.close();
 		}
 
@@ -599,14 +650,14 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 	selectTag() {
 		let tag;
-		if (isFunction(this.addTag())) {
-			tag = (<AddTagFn>this.addTag())(this.searchTerm);
+		if (isFunction(this.addTagState())) {
+			tag = (<AddTagFn>this.addTagState())(this.searchTerm);
 		} else {
 			tag = this._primitive ? this.searchTerm : { [this.bindLabel()]: this.searchTerm };
 		}
 
 		const handleTag = (item) =>
-			this.typeahead()?.observed || !this.isOpen() ? this.itemsList.mapItem(item, null) : this.itemsList.addItem(item);
+			this.typeaheadState()?.observed || !this.isOpen() ? this.itemsList.mapItem(item, null) : this.itemsList.addItem(item);
 		if (isPromise(tag)) {
 			tag.then((item) => this.select(handleTag(item))).catch(() => { });
 		} else if (tag) {
@@ -615,7 +666,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	showClear() {
-		return this.clearable() && (this.hasValue || this.searchTerm) && !this.disabled();
+		return this.clearableState() && (this.hasValue || this.searchTerm) && !this.disabled();
 	}
 
 	focusOnClear() {
@@ -626,8 +677,8 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	trackByOption = (_: number, item: NgOption) => {
-		if (this.trackByFn()) {
-			return this.trackByFn()(item.value);
+		if (this.trackByFnState()) {
+			return this.trackByFnState()(item.value);
 		}
 
 		return item;
@@ -636,15 +687,15 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	showNoItemsFound() {
 		const empty = this.itemsList.filteredItems.length === 0;
 		return (
-			((empty && !this.typeahead()?.observed && !this.loading()) ||
-				(empty && this.typeahead()?.observed && this._validTerm() && !this.loading())) &&
+			((empty && !this.typeaheadState()?.observed && !this.loadingState()) ||
+				(empty && this.typeaheadState()?.observed && this._validTerm() && !this.loadingState())) &&
 			!this.showAddTag
 		);
 	}
 
 	showTypeToSearch() {
 		const empty = this.itemsList.filteredItems.length === 0;
-		return empty && this.typeahead()?.observed && !this._validTerm() && !this.loading();
+		return empty && this.typeaheadState()?.observed && !this._validTerm() && !this.loadingState();
 	}
 
 	onCompositionStart() {
@@ -653,7 +704,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 	onCompositionEnd(term: string) {
 		this._isComposing = false;
-		if (this.searchWhileComposing()) {
+		if (this.searchWhileComposingState()) {
 			return;
 		}
 
@@ -661,19 +712,19 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	filter(term: string) {
-		if (this._isComposing && !this.searchWhileComposing()) {
+		if (this._isComposing && !this.searchWhileComposingState()) {
 			return;
 		}
 
 		this._searchTerm.set(term);
-		if (this.typeahead()?.observed && (this._validTerm() || this.minTermLength() === 0)) {
-			this.typeahead().next(term);
+		if (this.typeaheadState()?.observed && (this._validTerm() || this.minTermLengthState() === 0)) {
+			this.typeaheadState().next(term);
 		}
 
-		if (!this.typeahead()?.observed) {
+		if (!this.typeaheadState()?.observed) {
 			this.itemsList.filter(term);
 			if (this.isOpen()) {
-				this.itemsList.markSelectedOrDefault(this.markFirst());
+				this.itemsList.markSelectedOrDefault(this.markFirstState());
 			}
 		}
 
@@ -737,11 +788,11 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 		if (items.length > 0 && this.hasValue) {
 			this.itemsList.mapSelectedItems();
 		}
-		if (this.isOpen() && isDefined(this.searchTerm) && !this.typeahead()?.observed) {
+		if (this.isOpen() && isDefined(this.searchTerm) && !this.typeaheadState()?.observed) {
 			this.itemsList.filter(this.searchTerm);
 		}
-		if (this.typeahead()?.observed || this.isOpen()) {
-			this.itemsList.markSelectedOrDefault(this.markFirst());
+		if (this.typeaheadState()?.observed || this.isOpen()) {
+			this.itemsList.markSelectedOrDefault(this.markFirstState());
 		}
 	}
 
@@ -782,12 +833,12 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	private _isValidWriteValue(value: any): boolean {
-		if (!isDefined(value) || (this.multiple() && value === '') || (Array.isArray(value) && value.length === 0)) {
+		if (!isDefined(value) || (this.multipleState() && value === '') || (Array.isArray(value) && value.length === 0)) {
 			return false;
 		}
 
 		const validateBinding = (item: any): boolean => {
-			if (!isDefined(this.compareWith()) && isObject(item) && this.bindValue()) {
+			if (!isDefined(this.compareWithState()) && isObject(item) && this.bindValue()) {
 				this._console.warn(
 					`Setting object(${JSON.stringify(item)}) as your model with bindValue is not allowed unless [compareWith] is used.`,
 				);
@@ -796,7 +847,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			return true;
 		};
 
-		if (this.multiple()) {
+		if (this.multipleState()) {
 			if (!Array.isArray(value)) {
 				this._console.warn('Multiple select ngModel should be array.');
 				return false;
@@ -831,7 +882,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			}
 		};
 
-		if (this.multiple()) {
+		if (this.multipleState()) {
 			(<any[]>ngModel).forEach((item) => select(item));
 		} else {
 			select(ngModel);
@@ -839,7 +890,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	private _handleKeyPresses() {
-		if (this.searchable()) {
+		if (this.searchableState()) {
 			return;
 		}
 
@@ -874,7 +925,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			autocapitalize: 'off',
 			autocomplete: 'off',
 			'aria-controls': this.dropdownId,
-			...this.inputAttrs(),
+			...this.inputAttrsState(),
 		};
 
 		for (const key of Object.keys(attributes)) {
@@ -883,7 +934,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	private _setTabFocusOnClear() {
-		this.tabFocusOnClear.set(isDefined(this.tabFocusOnClearButton()) ? !!this.tabFocusOnClearButton() : this.config.tabFocusOnClear);
+		this.tabFocusOnClear.set(isDefined(this.tabFocusOnClearButtonState()) ? !!this.tabFocusOnClearButtonState() : this.config.tabFocusOnClear);
 	}
 
 	private _updateNgModel() {
@@ -892,8 +943,8 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			if (this.bindValue()) {
 				let value = null;
 				if (item.children) {
-					const groupKey = this.groupValue() ? this.bindValue() : <string>this.groupBy();
-					value = item.value[groupKey || <string>this.groupBy()];
+					const groupKey = this.groupValueState() ? this.bindValue() : <string>this.groupByState();
+					value = item.value[groupKey || <string>this.groupByState()];
 				} else {
 					value = this.itemsList.resolveNested(item.value, this.bindValue());
 				}
@@ -904,7 +955,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 		}
 
 		const selected = this.selectedItems.map((x) => x.value);
-		if (this.multiple()) {
+		if (this.multipleState()) {
 			this._onChange(model);
 			this.changeEvent.emit(selected);
 		} else {
@@ -926,8 +977,8 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 	private _changeSearch(searchTerm: string) {
 		this._searchTerm.set(searchTerm);
-		if (this.typeahead()?.observed) {
-			this.typeahead().next(searchTerm);
+		if (this.typeaheadState()?.observed) {
+			this.typeaheadState().next(searchTerm);
 		}
 	}
 
@@ -946,7 +997,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	private _onSelectionChanged() {
-		const appendTo = this.appendTo() ?? this.config.appendTo;
+		const appendTo = this.appendToState() ?? this.config.appendTo;
 		if (this.isOpen() && this.deselectOnClickValue() && appendTo) {
 			// Make sure items are rendered.
 			this._cd.detectChanges();
@@ -959,12 +1010,12 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			if (this.showClear() && !$event.shiftKey && this.tabFocusOnClear()) {
 				this.focusOnClear();
 				$event.preventDefault();
-			} else if (!this.addTag()) {
+			} else if (!this.addTagState()) {
 				return;
 			}
 		}
 
-		if (this.selectOnTab()) {
+		if (this.selectOnTabState()) {
 			if (this.itemsList.markedItem) {
 				this.toggleItem(this.itemsList.markedItem);
 				$event.preventDefault();
@@ -980,7 +1031,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	private _handleEnter($event: KeyboardEvent) {
-		const openOnEnter = this.openOnEnter() ?? this.config.openOnEnter;
+		const openOnEnter = this.openOnEnterState() ?? this.config.openOnEnter;
 		if (this.isOpen() || this._manualOpen) {
 			if (this.itemsList.markedItem) {
 				this.toggleItem(this.itemsList.markedItem);
@@ -1034,16 +1085,16 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	private _nextItemIsTag(nextStep: number): boolean {
 		const nextIndex = this.itemsList.markedIndex + nextStep;
 		return (
-			this.addTag() && this.searchTerm && this.itemsList.markedItem && (nextIndex < 0 || nextIndex === this.itemsList.filteredItems.length)
+			this.addTagState() && this.searchTerm && this.itemsList.markedItem && (nextIndex < 0 || nextIndex === this.itemsList.filteredItems.length)
 		);
 	}
 
 	private _handleBackspace() {
-		if (this.searchTerm || !this.clearable() || !this.clearOnBackspace() || !this.hasValue) {
+		if (this.searchTerm || !this.clearableState() || !this.clearOnBackspaceState() || !this.hasValue) {
 			return;
 		}
 
-		if (this.multiple()) {
+		if (this.multipleState()) {
 			this.unselect(this.itemsList.lastSelectedItem);
 		} else {
 			this.clearModel();
@@ -1065,7 +1116,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	 *  @returns `true` if virtual scroll is enabled, `false` otherwise
 	 */
 	private getVirtualScroll(config: NgSelectConfig): boolean {
-		return isDefined(this.virtualScroll) ? this.virtualScroll() : this.isVirtualScrollDisabled(config);
+		return isDefined(this.virtualScrollState) ? this.virtualScrollState() : this.isVirtualScrollDisabled(config);
 	}
 
 	/**

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -106,10 +106,31 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 	// signals
 	public readonly _disabled = signal<boolean>(false);
-	// inputs
+	readonly markFirst = signal<boolean>(true);
+	readonly loading = signal<boolean>(false);
+	readonly closeOnSelect = signal<boolean>(true);
+	readonly hideSelected = signal<boolean>(false);
+	readonly selectOnTab = signal<boolean>(false);
+	readonly openOnEnter = signal<boolean | undefined>(undefined);
+	readonly maxSelectedItems = signal<number | undefined>(undefined);
+	readonly bufferAmount = signal<number>(4);
+	readonly virtualScroll = signal<boolean | undefined>(undefined);
+	readonly selectableGroup = signal<boolean>(false);
+	readonly selectableGroupAsModel = signal<boolean>(true);
+	readonly clearOnBackspace = signal<boolean>(true);
+	readonly tabIndex = signal<number | undefined>(undefined);
+	readonly readonly = signal<boolean>(false);
+	readonly searchWhileComposing = signal<boolean>(true);
+	readonly minTermLength = signal<number>(0);
+	readonly editableSearchTerm = signal<boolean>(false);
+	readonly multiple = signal<boolean>(false);
+	readonly searchable = signal<boolean>(true);
+	readonly clearable = signal<boolean>(true);
+	readonly compareWith = signal<CompareWithFn | undefined>(undefined);
+
+	// models
 	readonly ariaLabelDropdown = model<string>('Options List');
 	readonly ariaLabel = model<string | undefined>(undefined);
-	readonly markFirst = model<boolean>(true);
 	readonly placeholder = model<string>(this.config.placeholder);
 	readonly fixedPlaceholder = model<boolean>(true);
 	readonly notFoundText = model<string>(undefined);
@@ -121,118 +142,104 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	readonly dropdownPosition = model<DropdownPosition>('auto');
 	readonly appendTo = model<string>(undefined);
 	readonly outsideClickEvent = model<'click' | 'mousedown'>(this.config.outsideClickEvent);
-	readonly loading = model<boolean>(false);
-	readonly closeOnSelect = model<boolean>(true);
-	readonly hideSelected = model<boolean>(false);
-	readonly selectOnTab = model<boolean>(false);
-	readonly openOnEnter = model<boolean | undefined>(undefined);
-	readonly maxSelectedItems = model<number | undefined>(undefined);
 	readonly groupBy = model<string | ((value: any) => any)>(undefined);
 	readonly groupValue = model<GroupValueFn>(undefined);
-	readonly bufferAmount = model<number>(4);
-	readonly virtualScroll = model<boolean | undefined>(undefined);
-	readonly selectableGroup = model<boolean>(false);
 	readonly tabFocusOnClearButton = model<boolean | undefined>(undefined);
-	readonly selectableGroupAsModel = model<boolean>(true);
 	readonly searchFn = model<any>(null);
 	readonly trackByFn = model<any>(null);
-	readonly clearOnBackspace = model<boolean>(true);
 	readonly labelForId = model<any>(null);
 	readonly inputAttrs = model<Record<string, string>>({});
-	readonly tabIndex = model<number | undefined>(undefined);
-	readonly readonly = model<boolean>(false);
-	readonly searchWhileComposing = model<boolean>(true);
-	readonly minTermLength = model<number>(0);
-	readonly editableSearchTerm = model<boolean>(false);
 	readonly ngClass = model<any>(null);
 	readonly typeahead = model<Subject<string> | undefined>(undefined);
-	readonly multiple = model<boolean>(false);
 	readonly addTag = model<boolean | AddTagFn>(false);
-	readonly searchable = model<boolean>(true);
-	readonly clearable = model<boolean>(true);
 	readonly deselectOnClick = model<boolean | undefined>(undefined);
 	readonly clearSearchOnAdd = model<any | undefined>(undefined);
-	readonly compareWith = model<CompareWithFn | undefined>(undefined);
 	readonly keyDownFn = model<(_: KeyboardEvent) => boolean>((_: KeyboardEvent) => true);
+	readonly bindLabel = model<string>(undefined);
+	readonly bindValue = model<string>(undefined);
+	readonly appearance = model<string>(undefined);
+	readonly isOpen = model<boolean | undefined>(false);
+	readonly items = model<readonly any[]>([]);
 
 	// @Input setters that need to apply transforms/validation
-	@Input('markFirst') set markFirstInput(v: any) {
+	/* eslint-disable @angular-eslint/no-input-rename */
+	@Input('markFirst') set markFirstInput(v: unknown) {
 		this.markFirst.set(booleanAttribute(v));
 	}
 
-	@Input('loading') set loadingInput(v: any) {
+	@Input('loading') set loadingInput(v: unknown) {
 		this.loading.set(booleanAttribute(v));
 	}
 
-	@Input('closeOnSelect') set closeOnSelectInput(v: any) {
+	@Input('closeOnSelect') set closeOnSelectInput(v: unknown) {
 		this.closeOnSelect.set(booleanAttribute(v));
 	}
 
-	@Input('hideSelected') set hideSelectedInput(v: any) {
+	@Input('hideSelected') set hideSelectedInput(v: unknown) {
 		this.hideSelected.set(booleanAttribute(v));
 	}
 
-	@Input('selectOnTab') set selectOnTabInput(v: any) {
+	@Input('selectOnTab') set selectOnTabInput(v: unknown) {
 		this.selectOnTab.set(booleanAttribute(v));
 	}
 
-	@Input('openOnEnter') set openOnEnterInput(v: any) {
+	@Input('openOnEnter') set openOnEnterInput(v: unknown) {
 		this.openOnEnter.set(booleanAttribute(v));
 	}
 
-	@Input('maxSelectedItems') set maxSelectedItemsInput(v: any) {
+	@Input('maxSelectedItems') set maxSelectedItemsInput(v: unknown) {
 		this.maxSelectedItems.set(numberAttribute(v));
 	}
 
-	@Input('bufferAmount') set bufferAmountInput(v: any) {
+	@Input('bufferAmount') set bufferAmountInput(v: unknown) {
 		this.bufferAmount.set(numberAttribute(v));
 	}
 
-	@Input('virtualScroll') set virtualScrollInput(v: any) {
+	@Input('virtualScroll') set virtualScrollInput(v: unknown) {
 		this.virtualScroll.set(booleanAttribute(v));
 	}
 
-	@Input('selectableGroup') set selectableGroupInput(v: any) {
+	@Input('selectableGroup') set selectableGroupInput(v: unknown) {
 		this.selectableGroup.set(booleanAttribute(v));
 	}
 
-	@Input('selectableGroupAsModel') set selectableGroupAsModelInput(v: any) {
+	@Input('selectableGroupAsModel') set selectableGroupAsModelInput(v: unknown) {
 		this.selectableGroupAsModel.set(booleanAttribute(v));
 	}
 
-	@Input('clearOnBackspace') set clearOnBackspaceInput(v: any) {
+	@Input('clearOnBackspace') set clearOnBackspaceInput(v: unknown) {
 		this.clearOnBackspace.set(booleanAttribute(v));
 	}
 
-	@Input('tabIndex') set tabIndexInput(v: any) {
+	@Input('tabIndex') set tabIndexInput(v: unknown) {
 		this.tabIndex.set(numberAttribute(v));
 	}
 
-	@Input('readonly') set readonlyInput(v: any) {
+	@Input('readonly') set readonlyInput(v: unknown) {
 		this.readonly.set(booleanAttribute(v));
 	}
 
-	@Input('searchWhileComposing') set searchWhileComposingInput(v: any) {
+	@Input('searchWhileComposing') set searchWhileComposingInput(v: unknown) {
 		this.searchWhileComposing.set(booleanAttribute(v));
 	}
 
-	@Input('minTermLength') set minTermLengthInput(v: any) {
+	@Input('minTermLength') set minTermLengthInput(v: unknown) {
 		this.minTermLength.set(numberAttribute(v));
 	}
 
-	@Input('editableSearchTerm') set editableSearchTermInput(v: any) {
+	@Input('editableSearchTerm') set editableSearchTermInput(v: unknown) {
 		this.editableSearchTerm.set(booleanAttribute(v));
 	}
 
-	@Input('multiple') set multipleInput(v: any) {
+	@Input('multiple') set multipleInput(v: unknown) {
 		this.multiple.set(booleanAttribute(v));
 	}
 
-	@Input('searchable') set searchableInput(v: any) {
+	@Input('searchable') set searchableInput(v: unknown) {
 		this.searchable.set(booleanAttribute(v));
 	}
 
-	@Input('clearable') set clearableInput(v: any) {
+	@Input('clearable') set clearableInput(v: unknown) {
 		this.clearable.set(booleanAttribute(v));
 	}
 
@@ -242,13 +249,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 		}
 		this.compareWith.set(fn);
 	}
-
-	// models
-	readonly bindLabel = model<string>(undefined);
-	readonly bindValue = model<string>(undefined);
-	readonly appearance = model<string>(undefined);
-	readonly isOpen = model<boolean | undefined>(false);
-	readonly items = model<readonly any[]>([]);
+	/* eslint-enable @angular-eslint/no-input-rename */
 
 	// output events
 	readonly blurEvent = output<any>({ alias: 'blur' });


### PR DESCRIPTION
## Problem

With the recent signal refactoring in `ng-select`, many component inputs were converted to **Angular input signals** using `input()`, often together with **input transforms** (e.g. boolean/number coercion).

While this improved internal reactivity, it unintentionally broke a valid and previously supported use case: **writing to `ng-select` inputs programmatically**, for example from a directive applied to `<ng-select>`.

In our application, we rely on directives that inject `NgSelectComponent` and dynamically configure inputs such as:

- `searchable`
- `typeahead`
- `searchFn`
- `multiple`
- `clearable`
- etc.

This pattern worked prior to the signal refactor but is no longer possible with readonly input signals.

A similar limitation has been raised by the community, for example when attempting to dynamically set `searchFn`:  
https://github.com/ng-select/ng-select/issues/2745

---

## Why Input Signals Are Insufficient

Angular input signals are intentionally **readonly from outside the component**. While this is correct for most components, it does not fit `ng-select`’s API surface, where many inputs are:

- Public
- Mutable
- Expected to be configurable at runtime

After the refactor, this pattern no longer works:

```ts
this.ngSelect.searchable = false;        // ❌ not a signal
this.ngSelect.searchable.set(false);     // ❌ inputs are readonly signals
```

This effectively removes support for directive-based configuration and dynamic behavior.

---

## Proposed Change – Use Writable Signals for Runtime-Configurable Options

This PR restores controlled external write access while keeping the component signal-based by:

- Replacing readonly `input()` signals with **writable signals**
- Preserving input coercion / validation (previously provided via `input(..., { transform })`) using explicit `@Input` setters where needed

This keeps template input behavior intact while allowing legitimate programmatic updates.

---

## Preserving Input Transforms and Validation

Some inputs previously relied on `input(..., { transform })` for coercion or validation. To preserve the same behavior, this PR keeps the transform logic in `@Input` setters and updates the underlying signal.

### Example: Boolean Inputs

```ts
readonly searchable = signal<boolean>(true);

@Input('searchable') set searchableInput(v: unknown) {
  this.searchable.set(booleanAttribute(v));
}
```

```ts
readonly multiple = signal<boolean>(false);

@Input('multiple') set multipleInput(v: unknown) {
  this.multiple.set(booleanAttribute(v));
}
```

### Example: Number Inputs

```ts
readonly minTermLength = signal<number>(0);

@Input('minTermLength') set minTermLengthInput(v: unknown) {
  this.minTermLength.set(numberAttribute(v));
}
```

### Example: Inputs With Validation

```ts
readonly compareWith = signal<CompareWithFn | undefined>(undefined);

@Input('compareWith') set compareWithInput(fn: CompareWithFn | undefined) {
  if (fn !== undefined && fn !== null && !isFunction(fn)) {
    throw Error('`compareWith` must be a function.');
  }
  this.compareWith.set(fn);
}
```

This ensures:

- Template bindings behave exactly as before  
- All existing transforms and validations are preserved  
- No breaking changes for current consumers  

---

## Directive Use Case – Restored Functionality

With inputs represented as **writable signals**, directives can once again configure `ng-select` at runtime by injecting the component and calling `.set(...)`:

```ts
@Directive({
  selector: '[appDynamicNgSelectConfig]',
})
export class DynamicNgSelectConfigDirective {
  constructor(private ngSelect: NgSelectComponent) {
    this.ngSelect.searchable.set(false);
    this.ngSelect.multiple.set(true);
    this.ngSelect.typeahead.set(new Subject<string>());
    this.ngSelect.searchFn.set((term, item) =>
      item.label.toLowerCase().includes(term.toLowerCase())
    );
  }
}
```

This was **not possible** when these options were readonly `input()` signals.

---

## Impact If This Is Not Supported

If these inputs remain readonly input signals:

- Directive-based configuration is permanently broken
- Dynamic runtime behavior (e.g. toggling search or changing `searchFn`) is no longer possible
- Advanced consumers must:
  - Fork `ng-select`
  - Replace it with another select library
  - Implement a custom select component

For our use case, this is **blocking** — migration to the signal-based version is not possible without writable inputs.

---

## Summary

- Readonly input signals unintentionally removed valid runtime configuration use cases
- Writable signals restore external configurability while keeping signals
- Coercion/validation is preserved via `@Input` setters
- This keeps the original API behavior intact while fixing the regression
