### PR TITLE
fix: update isOpen property type to enforce boolean only in NgSelectC…

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -165,7 +165,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	readonly bindLabel = model<string>(undefined);
 	readonly bindValue = model<string>(undefined);
 	readonly appearance = model<string>(undefined);
-	readonly isOpen = model<boolean | undefined>(false);
+	readonly isOpen = model<boolean>(false);
 	readonly items = model<readonly any[]>([]);
 
 	// output events


### PR DESCRIPTION
…omponent

- Changed the type of the `isOpen` property from `boolean | undefined` to `boolean` to ensure it always has a defined state.
- This change improves type safety and consistency in the component's behavior.

Fixes #2733