### PR TITLE
fix: prevent dropdown from closing when browser scrolls on click

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -97,6 +97,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges {
 	private _scrollToEndFired = false;
 	private _updateScrollHeight = false;
 	private _lastScrollPosition = 0;
+	private _lastMousedownTarget: EventTarget | null = null;
 
 	constructor() {
 		this._destroyRef.onDestroy(() => {
@@ -237,6 +238,12 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges {
 		}
 
 		this._zone.runOutsideAngular(() => {
+			fromEvent(this._document, 'mousedown', { capture: true })
+				.pipe(takeUntilDestroyed(this._destroyRef))
+				.subscribe(($event: Event) => {
+					this._lastMousedownTarget = $event.target;
+				});
+
 			fromEvent(this._document, this.outsideClickEvent(), { capture: true })
 				.pipe(takeUntilDestroyed(this._destroyRef))
 				.subscribe(($event) => this._checkToClose($event));
@@ -245,6 +252,17 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges {
 
 	private _checkToClose($event: any) {
 		if (this._select.contains($event.target) || this._dropdown.contains($event.target)) {
+			return;
+		}
+
+		// If the mousedown originated inside the select/dropdown, do not treat
+		// the subsequent click as an outside click. This handles the case where
+		// focus() scrolls the page between mousedown and mouseup, causing the
+		// click target to land outside the component.
+		if (
+			this._lastMousedownTarget &&
+			(this._select.contains(this._lastMousedownTarget as Node) || this._dropdown.contains(this._lastMousedownTarget as Node))
+		) {
 			return;
 		}
 

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -101,6 +101,7 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges {
 
 	constructor() {
 		this._destroyRef.onDestroy(() => {
+			this._lastMousedownTarget = null;
 			if (this.appendTo()) {
 				this._renderer.removeChild(this._dropdown.parentNode, this._dropdown);
 			}
@@ -259,9 +260,11 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges {
 		// the subsequent click as an outside click. This handles the case where
 		// focus() scrolls the page between mousedown and mouseup, causing the
 		// click target to land outside the component.
+		const mousedownTarget = this._lastMousedownTarget;
+		this._lastMousedownTarget = null;
 		if (
-			this._lastMousedownTarget &&
-			(this._select.contains(this._lastMousedownTarget as Node) || this._dropdown.contains(this._lastMousedownTarget as Node))
+			mousedownTarget &&
+			(this._select.contains(mousedownTarget as Node) || this._dropdown.contains(mousedownTarget as Node))
 		) {
 			return;
 		}

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2508,6 +2508,39 @@ describe('NgSelectComponent', () => {
 			tickAndDetectChanges(fixture);
 			expect(select.isOpen()).toBeTruthy();
 		}));
+
+		it('should not close dropdown when mousedown is inside select but click lands outside (scroll scenario)', fakeAsync(() => {
+			triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
+			tickAndDetectChanges(fixture);
+			expect(select.isOpen()).toBeTruthy();
+
+			const selectEl = document.getElementById('select');
+			const outsideEl = document.getElementById('outside');
+
+			// Simulate: mousedown inside select, then browser scrolls, click lands outside
+			const mousedownEvent = new MouseEvent('mousedown', { bubbles: true });
+			selectEl.dispatchEvent(mousedownEvent);
+			outsideEl.click();
+
+			tickAndDetectChanges(fixture);
+			expect(select.isOpen()).toBeTruthy();
+		}));
+
+		it('should still close dropdown on genuine outside click (mousedown and click both outside)', fakeAsync(() => {
+			triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
+			tickAndDetectChanges(fixture);
+			expect(select.isOpen()).toBeTruthy();
+
+			const outsideEl = document.getElementById('outside');
+
+			// Both mousedown and click are on the outside element
+			const mousedownEvent = new MouseEvent('mousedown', { bubbles: true });
+			outsideEl.dispatchEvent(mousedownEvent);
+			outsideEl.click();
+
+			tickAndDetectChanges(fixture);
+			expect(select.isOpen()).toBeFalsy();
+		}));
 	});
 
 	describe('Dropdown position', () => {

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2543,6 +2543,55 @@ describe('NgSelectComponent', () => {
 		}));
 	});
 
+	describe('Outside click without appendTo', () => {
+		let fixture: ComponentFixture<NgSelectTestComponent>;
+		let select: NgSelectComponent;
+		beforeEach(() => {
+			fixture = createTestingModule(
+				NgSelectTestComponent,
+				`<div id="outside">Outside</div><br />
+                <ng-select id="select" [items]="cities"
+                    bindLabel="name"
+                    multiple="true"
+                    [closeOnSelect]="false"
+                    [(ngModel)]="selectedCity">
+                </ng-select>`,
+			);
+			select = fixture.componentInstance.select();
+		});
+
+		it('should not close dropdown when mousedown is inside select but click lands outside (scroll scenario)', fakeAsync(() => {
+			triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
+			tickAndDetectChanges(fixture);
+			expect(select.isOpen()).toBeTruthy();
+
+			const selectEl = document.getElementById('select');
+			const outsideEl = document.getElementById('outside');
+
+			const mousedownEvent = new MouseEvent('mousedown', { bubbles: true });
+			selectEl.dispatchEvent(mousedownEvent);
+			outsideEl.click();
+
+			tickAndDetectChanges(fixture);
+			expect(select.isOpen()).toBeTruthy();
+		}));
+
+		it('should still close dropdown on genuine outside click', fakeAsync(() => {
+			triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Space);
+			tickAndDetectChanges(fixture);
+			expect(select.isOpen()).toBeTruthy();
+
+			const outsideEl = document.getElementById('outside');
+
+			const mousedownEvent = new MouseEvent('mousedown', { bubbles: true });
+			outsideEl.dispatchEvent(mousedownEvent);
+			outsideEl.click();
+
+			tickAndDetectChanges(fixture);
+			expect(select.isOpen()).toBeFalsy();
+		}));
+	});
+
 	describe('Dropdown position', () => {
 		it('should auto position dropdown to bottom by default', fakeAsync(() => {
 			const fixture = createTestingModule(NgSelectTestComponent, `<ng-select [items]="cities"></ng-select>`);


### PR DESCRIPTION
## Fixes #2773

### Description

When an `ng-select` is partially out of the viewport and the user clicks on it, the browser auto-scrolls to bring the focused input into view. This scroll shifts the page between `mousedown` and `click`, causing the `click` event target to land on a different element outside the component. The `_checkToClose` handler in the dropdown panel interprets this as an outside click and immediately closes the dropdown.

### Root Cause

1. `mousedown` on `.ng-select-container` → `handleMousedown()` → `focus()` → browser auto-scrolls
2. Page scrolls → cursor is now over a different element
3. `click` event fires with target outside the `ng-select`
4. `_checkToClose()` emits `outsideClick` → dropdown closes

This is exacerbated by `scroll-margin-top` CSS (e.g., for sticky headers/footers).

### Fix

Track the `mousedown` event target in `_handleOutsideClick`. In `_checkToClose`, if the preceding `mousedown` originated inside the select or dropdown, do not treat the `click` as an outside click. This correctly identifies the user's intent (they clicked inside the select) regardless of where the click target ends up after scrolling.

### Changes

- **`ng-dropdown-panel.component.ts`**: Added `_lastMousedownTarget` field, a document `mousedown` listener to track click origin, and a guard in `_checkToClose` to skip closing when mousedown was inside the component.
- **`ng-select.component.spec.ts`**: Added 2 test cases:
  - Dropdown stays open when mousedown is inside but click lands outside (scroll scenario)
  - Dropdown still closes on genuine outside click (mousedown and click both outside)

### How to test

1. Ensure the browser window height introduces a scrollbar on the [multiselect demo](https://ng-select.github.io/ng-select/#/multiselect)
2. Scroll down so the top of the select control is out of view
3. Click the select control
4. **Expected:** browser scrolls into view and dropdown remains open
5. Click outside the select → dropdown closes normally