### PR TITLE
A11y chips tabstops

### DIFF
--- a/src/ng-select/lib/config.service.ts
+++ b/src/ng-select/lib/config.service.ts
@@ -19,6 +19,7 @@ export class NgSelectConfig {
 	clearSearchOnAdd: boolean;
 	deselectOnClick: boolean;
 	tabFocusOnClear = true;
+	tabFocusOnChips = false;
 	/**
 	 * Controls which DOM event is used to detect outside clicks for closing the dropdown.
 	 * Defaults to 'click'. Set to 'mousedown' to handle early outside interactions

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -16,7 +16,7 @@
 			@for (item of selectedItems; track trackByOption($index, item)) {
 				<div [class.ng-value-disabled]="item.disabled" class="ng-value">
 					<ng-template #defaultLabelTemplate>
-						<span class="ng-value-icon left" (click)="unselect(item)" (keydown.enter)="unselect(item)" [attr.tabindex]="(tabFocusOnChips() ?? config.tabFocusOnChips) ? 0 : -1" role="button" [attr.aria-label]="'Remove ' + item.label">×</span>
+						<span class="ng-value-icon left" (click)="unselect(item)" (keydown.enter)="unselect(item)" (keydown.space)="$event.preventDefault(); unselect(item)" [attr.tabindex]="(tabFocusOnChips() ?? config.tabFocusOnChips) ? 0 : -1" role="button" [attr.aria-label]="'Remove ' + item.label">×</span>
 						<span class="ng-value-label" [ngItemLabel]="item.label" [escape]="escapeHTML"></span>
 					</ng-template>
 					<ng-template

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -16,7 +16,7 @@
 			@for (item of selectedItems; track trackByOption($index, item)) {
 				<div [class.ng-value-disabled]="item.disabled" class="ng-value">
 					<ng-template #defaultLabelTemplate>
-						<span class="ng-value-icon left" (click)="unselect(item)" aria-hidden="true">×</span>
+						<span class="ng-value-icon left" (click)="unselect(item)" (keydown.enter)="unselect(item)" [attr.tabindex]="(tabFocusOnChips() ?? config.tabFocusOnChips) ? 0 : -1" role="button" [attr.aria-label]="'Remove ' + item.label">×</span>
 						<span class="ng-value-label" [ngItemLabel]="item.label" [escape]="escapeHTML"></span>
 					</ng-template>
 					<ng-template

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2618,6 +2618,33 @@ describe('NgSelectComponent', () => {
 			expect(select.selectedItems.length).toBe(1);
 			expect(select.selectedItems[0].value).toEqual(fixture.componentInstance.cities[1]);
 		}));
+
+		it('should remove item when Space is pressed on chip remove button', fakeAsync(() => {
+			const fixture = createTestingModule(NgSelectTestComponent, template);
+			fixture.componentInstance.tabFocusOnChips = true;
+			const icons = setupChips(fixture);
+
+			icons[0].triggerEventHandler('keydown.space', { key: ' ', preventDefault: () => {} });
+			tickAndDetectChanges(fixture);
+
+			const select = fixture.componentInstance.select();
+			expect(select.selectedItems.length).toBe(1);
+			expect(select.selectedItems[0].value).toEqual(fixture.componentInstance.cities[1]);
+		}));
+
+		it('should not intercept Tab key on chips so browser handles natural tab order', fakeAsync(() => {
+			const fixture = createTestingModule(NgSelectTestComponent, template);
+			fixture.componentInstance.tabFocusOnChips = true;
+			setupChips(fixture);
+
+			const select = fixture.componentInstance.select();
+			const spy = spyOn(select, 'handleKeyCodeInput');
+
+			const chipEl: HTMLElement = fixture.debugElement.query(By.css('.ng-value-icon')).nativeElement;
+			chipEl.dispatchEvent(new KeyboardEvent('keydown', { key: KeyCode.Tab, bubbles: true }));
+
+			expect(spy).not.toHaveBeenCalled();
+		}));
 	});
 
 	describe('Outside click', () => {

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2561,6 +2561,65 @@ describe('NgSelectComponent', () => {
 		}));
 	});
 
+	describe('Tab focus on chips', () => {
+		const template = `<ng-select [items]="cities" bindLabel="name" [multiple]="true"
+			[tabFocusOnChips]="tabFocusOnChips" [(ngModel)]="selectedCities"></ng-select>`;
+
+		function setupChips(fixture: ComponentFixture<NgSelectTestComponent>) {
+			fixture.componentInstance.selectedCities = [fixture.componentInstance.cities[0], fixture.componentInstance.cities[1]];
+			tickAndDetectChanges(fixture);
+			tickAndDetectChanges(fixture);
+			return fixture.debugElement.queryAll(By.css('.ng-value-icon'));
+		}
+
+		it('should set tabindex and aria attributes on chip remove buttons based on tabFocusOnChips', fakeAsync(() => {
+			const fixture = createTestingModule(NgSelectTestComponent, template);
+			fixture.componentInstance.tabFocusOnChips = true;
+			const icons = setupChips(fixture);
+
+			expect(icons.length).toBe(2);
+			expect(icons[0].nativeElement.getAttribute('tabindex')).toBe('0');
+			expect(icons[0].nativeElement.getAttribute('role')).toBe('button');
+			expect(icons[0].nativeElement.getAttribute('aria-label')).toBe('Remove New York');
+
+			// default (false) should use tabindex -1
+			fixture.componentInstance.tabFocusOnChips = false;
+			tickAndDetectChanges(fixture);
+			const updatedIcons = fixture.debugElement.queryAll(By.css('.ng-value-icon'));
+			expect(updatedIcons[0].nativeElement.getAttribute('tabindex')).toBe('-1');
+		}));
+
+		it('should respect global config and allow input override', fakeAsync(() => {
+			const config = new NgSelectConfig();
+			config.tabFocusOnChips = true;
+			const fixture = createTestingModule(NgSelectTestComponent, template, config);
+			fixture.componentInstance.selectedCities = [fixture.componentInstance.cities[0]];
+			tickAndDetectChanges(fixture);
+			tickAndDetectChanges(fixture);
+
+			// global config enables it
+			expect(fixture.debugElement.query(By.css('.ng-value-icon')).nativeElement.getAttribute('tabindex')).toBe('0');
+
+			// input overrides global config
+			fixture.componentInstance.tabFocusOnChips = false;
+			tickAndDetectChanges(fixture);
+			expect(fixture.debugElement.query(By.css('.ng-value-icon')).nativeElement.getAttribute('tabindex')).toBe('-1');
+		}));
+
+		it('should remove item when Enter is pressed on chip remove button', fakeAsync(() => {
+			const fixture = createTestingModule(NgSelectTestComponent, template);
+			fixture.componentInstance.tabFocusOnChips = true;
+			const icons = setupChips(fixture);
+
+			icons[0].triggerEventHandler('keydown.enter', { key: 'Enter', preventDefault: () => {} });
+			tickAndDetectChanges(fixture);
+
+			const select = fixture.componentInstance.select();
+			expect(select.selectedItems.length).toBe(1);
+			expect(select.selectedItems[0].value).toEqual(fixture.componentInstance.cities[1]);
+		}));
+	});
+
 	describe('Outside click', () => {
 		let fixture: ComponentFixture<NgSelectTestComponent>;
 		let select: NgSelectComponent;
@@ -2996,10 +3055,10 @@ describe('NgSelectComponent', () => {
 		it('should display ng-placeholder if an item is selected', fakeAsync(() => {
 			const fixture = createTestingModule(
 				NgSelectTestComponent,
-				`<ng-select [(ngModel)]="selectedCity" 
-														 [items]="cities" bindLabel="name" 
+				`<ng-select [(ngModel)]="selectedCity"
+														 [items]="cities" bindLabel="name"
 														 fixedPlaceholder="true"
-														 placeholder="testPlaceholder">			
+														 placeholder="testPlaceholder">
                   </ng-select>`,
 			);
 
@@ -5596,6 +5655,7 @@ class NgSelectTestComponent {
 	searchFn: (term: string, item: any) => boolean = null;
 	selectOnTab = true;
 	tabFocusOnClearButton: boolean;
+	tabFocusOnChips: boolean;
 	hideSelected = false;
 	closeOnSelect = true;
 	clearable = true;

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -470,10 +470,14 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	handleKeyCode($event: KeyboardEvent) {
-		const target = $event.target;
+		const target = $event.target as HTMLElement;
 
 		if (this.clearButton() && this.clearButton().nativeElement === target) {
 			this.handleKeyCodeClear($event);
+		} else if (target?.classList?.contains('ng-value-icon')) {
+			// Chip remove buttons handle their own events via template bindings (Enter for removal).
+			// Tab/Shift+Tab navigation between chips is handled naturally by the browser via tabindex.
+			return;
 		} else {
 			this.handleKeyCodeInput($event);
 		}

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -185,7 +185,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	readonly _tabFocusOnClearButton = input<boolean | undefined>(undefined, { alias: 'tabFocusOnClearButton' });
 	readonly tabFocusOnClearButton = linkedSignal(() => this._tabFocusOnClearButton());
 
-	readonly _tabFocusOnChips = input<boolean | undefined>(undefined, { alias: 'tabFocusOnChips', transform: booleanAttribute });
+	readonly _tabFocusOnChips = input<boolean | undefined>(undefined, { alias: 'tabFocusOnChips' });
 	readonly tabFocusOnChips = linkedSignal(() => this._tabFocusOnChips());
 
 	readonly _selectableGroupAsModel = input(true, { alias: 'selectableGroupAsModel', transform: booleanAttribute });

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -185,6 +185,9 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	readonly _tabFocusOnClearButton = input<boolean | undefined>(undefined, { alias: 'tabFocusOnClearButton' });
 	readonly tabFocusOnClearButton = linkedSignal(() => this._tabFocusOnClearButton());
 
+	readonly _tabFocusOnChips = input<boolean | undefined>(undefined, { alias: 'tabFocusOnChips', transform: booleanAttribute });
+	readonly tabFocusOnChips = linkedSignal(() => this._tabFocusOnChips());
+
 	readonly _selectableGroupAsModel = input(true, { alias: 'selectableGroupAsModel', transform: booleanAttribute });
 	readonly selectableGroupAsModel = linkedSignal(() => this._selectableGroupAsModel());
 


### PR DESCRIPTION
## Summary

According to an accessibility review we need to have tab stops on each selected item (chip) in case of a multi select dropdown. The chips are currently not selectable by keyboard. This hurts the Operable principle of accessibility, specifically keyboard accessibility.

An alternative solution could be a custom template but that would generate large amount of code.

## Changes made

Introduced the "tabFocusOnChips" signal based input property.
The default value is false, which means the feature is turned off by default.


## Tests

Created 5 additional test specs in "Tab focus on chips" test suite

- [x] All tests passed.

## Disclaimer
Code generated by Github copilot using Claude Opus/Sonnet/Haiku models
(c) 2026 Deutsche Telekom IT GmbH

