### PR TITLE
fix: add notched outline appearance to ng-select component

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,7 @@
 			"runtimeExecutable": "pnpm",
 			"runtimeArgs": ["ng", "serve", "--port", "4300"],
 			"port": 4300,
-			"autoPort": false
+			"autoPort": true
 		}
 	]
 }

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: verify
+description: Use when verifying an ng-select change at runtime — launching the demo app, driving a component behavior in the browser, or running the repo's test/lint/build pipeline before claiming a change works.
+---
+
+# Verifying ng-select changes
+
+## Launch the demo app
+
+Use the Browser pane, never Bash: `preview_start {name: "demo"}` (config in `.claude/launch.json`, pnpm ng serve). If port 4300 is taken by another session, `autoPort: true` lets it pick a free port.
+
+Demo routes are hash-based: `http://localhost:<port>/#/forms`, `#/data-sources`, etc. (see `src/demo/app/routes.ts`).
+
+## Drive component behaviors
+
+- Theme switcher and LTR/RTL toggle are dropdowns in the demo header. Material theme is required for `appearance="outline"` / `appearance="fill"` styling.
+- Outline-appearance selects live on `#/forms` ("Reactive form using ng-option" example).
+- To test on a non-white background: `javascript_tool` → `document.body.style.background = '#263238'` and clear card backgrounds.
+
+## Gotchas
+
+- **Theme resets to `default` on full page reload** (component state, not persisted) — re-select Material after any force reload before judging appearance styles.
+- **Opening a select programmatically:** dispatch `keydown` Space on the `ng-select` host element (`new KeyboardEvent('keydown', {keyCode: 32, ...})`). Synthetic `mousedown` on the container is unreliable, and coordinate clicks fight scroll jumps.
+
+- **Demo RTL does not exercise theme RTL rules.** The demo nests themes under `:host.<x>-theme ::ng-deep` (app.component.scss) and puts `dir` on an inner div, so the themes' `@include rtl` rules (`[dir='rtl'] …` at root) never match in the demo. To verify RTL as real consumers see it, set `document.documentElement.dir = 'rtl'` via javascript_tool.
+- Unit tests run in real Chromium (Vitest + browser-playwright), not jsdom — layout measurement (`offsetWidth` etc.) works in specs.
+
+## Pipeline (Definition of Done, AGENTS.md)
+
+```bash
+pnpm lint
+pnpm exec ng test ng-select --watch=false
+pnpm run build
+pnpm exec prettier --check <changed files>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist.tgz
 .nx/workspace-data
 .superpowers/
 jasmine-vitest-*.md
+.vitest-attachments
+src/ng-select/lib/__screenshots__/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ ng-select is an **Angular 22** component library published as two npm packages, 
 - **Angular**: **Standalone components** are primary; `NgSelectModule` remains for backward compatibility—do not remove without an explicit migration plan.
 - **Change detection**: Core components use **OnPush**. Mutating `items` in place will not trigger updates; assign new array references.
 - **Signals in library code**: Prefer `input()`, `output()`, and `model()` for new APIs. The main component uses the `_foo` + `linkedSignal()` pattern to preserve stable public property names—follow that when extending `NgSelectComponent`.
-- **Tests**: Vitest + jsdom (`pnpm test`, `pnpm test:ci`). No Playwright e2e in this repo.
+- **Tests**: Vitest browser mode — headless **Chromium** via Playwright (`vitest.config.ts`); `pnpm test`, `pnpm test:ci`. Playwright is only the unit-test browser provider — there is no separate e2e suite.
 - **Commits**: Use [Conventional Commits](https://www.conventionalcommits.org/) format (required by semantic-release).
 
 ---
@@ -255,7 +255,7 @@ These rules come from [`.cursor/rules/rules.mdc`](./.cursor/rules/rules.mdc) and
 
 ### 10. Testing
 
-- Use Karma and Jasmine APIs (`fakeAsync`, `tick`, `TestBed`, component fixtures).
+- Use Vitest APIs (`vi.spyOn`, `expect`) with Angular testing utilities (`fakeAsync`, `tick`, `TestBed`, component fixtures).
 - Update existing specs when behavior changes; follow helpers in `src/ng-select/testing/`.
 - Test keyboard navigation, selection, and forms integration for library changes.
 
@@ -364,11 +364,11 @@ When changing styles, verify all three themes and check validation-state styling
 
 - **DO NOT** add new unit tests unless explicitly requested or needed to cover changed behavior.
 - **SHOULD** update existing specs when modifying behavior already covered by tests.
-- Test stack: **Vitest** + **jsdom** + `zone.js/testing`.
+- Test stack: **Vitest browser mode** (headless **Chromium** via `@vitest/browser-playwright`, wired through `@angular/build:unit-test` and `vitest.config.ts`) + `zone.js/testing`. Failed specs save screenshots to `src/ng-select/lib/__screenshots__/`.
 - Main spec: `src/ng-select/lib/ng-select.component.spec.ts` (extensive coverage—follow its patterns).
 - Helpers: `src/ng-select/testing/helpers.ts`, mocks in `src/ng-select/testing/mocks.ts`.
 - Use `fakeAsync`, `tick`, `tickAndDetectChanges`, and `selectOption` helpers for keyboard/dropdown interactions.
-- CI runs `pnpm test:ci` (headless Chrome) and reports coverage to Coveralls.
+- CI runs `pnpm test:ci` (headless Chromium) and reports coverage to Coveralls.
 - Code coverage excludes: `testing/*`, barrel files, `console.service.ts`, `search-helper.ts`, `ng-templates.directive.ts`.
 
 For substantial library changes:

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -81,6 +81,14 @@
 	<span class="ng-arrow-wrapper">
 		<span class="ng-arrow"></span>
 	</span>
+
+	@if (appearance() === 'outline') {
+		<div class="ng-notched-outline" aria-hidden="true">
+			<div class="ng-notched-outline-leading"></div>
+			<div class="ng-notched-outline-notch" [style.width.px]="outlineNotchWidth()"></div>
+			<div class="ng-notched-outline-trailing"></div>
+		</div>
+	}
 </div>
 
 @if (isOpen()) {

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -185,6 +185,34 @@ describe('NgSelectComponent', () => {
 			expect(ngSelectContainer.classList.contains('ng-appearance-outline')).toBe(true);
 			expect(ngSelectContainer.classList.contains('ng-appearance-fill')).toBe(false);
 		});
+
+		it('should render notched outline elements when appearance is outline', () => {
+			const fixture = createTestingModule(NgSelectTestComponent, `<ng-select appearance="outline" placeholder="Select city"></ng-select>`);
+
+			const outline: HTMLElement = fixture.nativeElement.querySelector('.ng-select-container > .ng-notched-outline');
+			expect(outline).toBeTruthy();
+			expect(outline.querySelector('.ng-notched-outline-leading')).toBeTruthy();
+			expect(outline.querySelector('.ng-notched-outline-notch')).toBeTruthy();
+			expect(outline.querySelector('.ng-notched-outline-trailing')).toBeTruthy();
+		});
+
+		it('should not render notched outline elements for other appearances', () => {
+			const fixture = createTestingModule(NgSelectTestComponent, `<ng-select placeholder="Select city"></ng-select>`);
+
+			expect(fixture.nativeElement.querySelector('.ng-notched-outline')).toBeNull();
+		});
+
+		it('should size the outline notch to the scaled placeholder width', async () => {
+			const fixture = createTestingModule(NgSelectTestComponent, `<ng-select appearance="outline" placeholder="Select city"></ng-select>`);
+			await tickAndDetectChanges(fixture);
+
+			const placeholder: HTMLElement = fixture.nativeElement.querySelector('.ng-placeholder');
+			Object.defineProperty(placeholder, 'offsetWidth', { value: 100 });
+			await tickAndDetectChanges(fixture);
+
+			const notch: HTMLElement = fixture.nativeElement.querySelector('.ng-notched-outline-notch');
+			expect(notch.style.width).toBe('75px');
+		});
 	});
 
 	describe('Input attributes', () => {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -1,4 +1,5 @@
 import {
+	afterEveryRender,
 	AfterViewInit,
 	booleanAttribute,
 	ChangeDetectionStrategy,
@@ -287,6 +288,8 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	// public variables
 	readonly dropdownId = newId();
 	readonly element: HTMLElement;
+	/** Width of the notched-outline gap for the floated label in the material outline appearance */
+	readonly outlineNotchWidth = signal(0);
 	// variables
 	escapeHTML = true;
 	itemsList: ItemsList;
@@ -321,6 +324,25 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 		this.itemsList = new ItemsList(this, newSelectionModel ? newSelectionModel() : DefaultSelectionModelFactory());
 		this.element = _elementRef.nativeElement;
 		this._handleSignalChanges();
+		afterEveryRender({
+			read: () => this._measureOutlineNotch(),
+		});
+	}
+
+	/**
+	 * Measures the placeholder label so the notched outline can leave a real gap in the border
+	 * for the floated label instead of masking it with an opaque background (material theme).
+	 * The 0.75 factor matches the `scale(0.75)` the material theme applies to the floated label.
+	 */
+	private _measureOutlineNotch() {
+		if (this.appearance() !== 'outline') {
+			return;
+		}
+		const label = this.element.querySelector<HTMLElement>('.ng-select-container > .ng-value-container .ng-placeholder');
+		const width = label ? label.offsetWidth * 0.75 : 0;
+		if (width !== this.outlineNotchWidth()) {
+			this.outlineNotchWidth.set(width);
+		}
 	}
 
 	private _focused: boolean;

--- a/src/ng-select/themes/material.theme.scss
+++ b/src/ng-select/themes/material.theme.scss
@@ -28,6 +28,18 @@ $ng-select-bg: #ffffff !default;
 					border-bottom: none;
 				}
 			}
+			&.ng-appearance-outline {
+				.ng-notched-outline,
+				&:hover .ng-notched-outline {
+					--ng-select-outline-width: 1px;
+					color: $ng-select-divider;
+				}
+				.ng-notched-outline-leading,
+				.ng-notched-outline-notch,
+				.ng-notched-outline-trailing {
+					border-style: dotted;
+				}
+			}
 			.ng-value-container {
 				.ng-value {
 					color: $ng-select-disabled-text;
@@ -49,10 +61,10 @@ $ng-select-bg: #ffffff !default;
 				border-width: 2px;
 			}
 			&.ng-appearance-outline {
-				&:after,
-				&:hover:after {
-					border-color: $ng-select-highlight;
-					border-width: 2px;
+				.ng-notched-outline,
+				&:hover .ng-notched-outline {
+					--ng-select-outline-width: 2px;
+					color: $ng-select-highlight;
 				}
 			}
 			&.ng-appearance-fill {
@@ -82,6 +94,9 @@ $ng-select-bg: #ffffff !default;
 			transform: translateY(-1.28125em) scale(0.75) perspective(100px) translateZ(0.001px);
 		}
 	}
+	&.ng-select-opened .ng-select-container.ng-appearance-outline .ng-notched-outline-notch {
+		border-top-width: 0;
+	}
 	.ng-select-container {
 		color: $ng-select-primary-text;
 		align-items: baseline;
@@ -98,20 +113,64 @@ $ng-select-bg: #ffffff !default;
 		&.ng-appearance-outline {
 			padding: 0 0.5em;
 			min-height: 60px;
+			// The outline is drawn by .ng-notched-outline segments so the floated label
+			// sits in a real border gap and works on any page background.
 			&:after {
-				border: solid 1px $ng-select-divider;
-				border-radius: 5px;
-				height: calc(100% - 0.5em);
-				pointer-events: none;
-				transition: border-color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+				display: none;
 			}
-			&:hover:after {
-				border-color: $ng-select-primary-text;
-				border-width: 2px;
+			&:hover .ng-notched-outline {
+				--ng-select-outline-width: 2px;
+				color: $ng-select-primary-text;
+			}
+			.ng-notched-outline {
+				--ng-select-outline-width: 1px;
+				position: absolute;
+				bottom: 0;
+				left: 0;
+				right: 0;
+				height: calc(100% - 0.5em);
+				display: flex;
+				pointer-events: none;
+				color: $ng-select-divider;
+				transition: color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+			}
+			.ng-notched-outline-leading,
+			.ng-notched-outline-notch,
+			.ng-notched-outline-trailing {
+				box-sizing: border-box;
+				height: 100%;
+				border: 0 solid currentColor;
+				transition: border-width 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+			}
+			.ng-notched-outline-leading {
+				border-width: var(--ng-select-outline-width) 0 var(--ng-select-outline-width) var(--ng-select-outline-width);
+				border-radius: 5px 0 0 5px;
+				width: 0.5em;
+				flex-shrink: 0;
+				@include rtl {
+					border-width: var(--ng-select-outline-width) var(--ng-select-outline-width) var(--ng-select-outline-width) 0;
+					border-radius: 0 5px 5px 0;
+				}
+			}
+			.ng-notched-outline-notch {
+				border-width: var(--ng-select-outline-width) 0;
+				flex-shrink: 0;
+				max-width: calc(100% - 1em);
+			}
+			.ng-notched-outline-trailing {
+				border-width: var(--ng-select-outline-width) var(--ng-select-outline-width) var(--ng-select-outline-width) 0;
+				border-radius: 0 5px 5px 0;
+				flex-grow: 1;
+				@include rtl {
+					border-width: var(--ng-select-outline-width) 0 var(--ng-select-outline-width) var(--ng-select-outline-width);
+					border-radius: 5px 0 0 5px;
+				}
+			}
+			&.ng-has-value .ng-notched-outline-notch {
+				border-top-width: 0;
 			}
 			.ng-placeholder {
 				padding: 0 0.25em;
-				background-color: $ng-select-bg;
 				z-index: 1;
 			}
 			.ng-value {
@@ -214,10 +273,15 @@ $ng-select-bg: #ffffff !default;
 				}
 			}
 			.ng-appearance-outline {
-				&:after,
-				&:hover:after {
-					background-image: none;
-					border: dotted 1px $ng-select-divider;
+				.ng-notched-outline,
+				&:hover .ng-notched-outline {
+					--ng-select-outline-width: 1px;
+					color: $ng-select-divider;
+				}
+				.ng-notched-outline-leading,
+				.ng-notched-outline-notch,
+				.ng-notched-outline-trailing {
+					border-style: dotted;
 				}
 			}
 		}


### PR DESCRIPTION
- Implemented a new 'outline' appearance for the ng-select component, featuring a notched outline that adjusts based on the placeholder width.
- Updated the component's HTML and SCSS to support the new appearance, ensuring proper styling and behavior.
- Enhanced unit tests to verify the rendering of notched outline elements and their sizing based on the placeholder.
- Updated documentation to reflect changes in testing expectations and component behavior.

Closes #2797
This feature improves the visual consistency and usability of the ng-select component in material design contexts.