### PR TITLE
fix(security): render default labels as text to prevent XSS (#2374)

### DIFF
--- a/src/ng-select/lib/ng-option.component.ts
+++ b/src/ng-select/lib/ng-option.component.ts
@@ -25,8 +25,8 @@ export class NgOptionComponent implements OnInit {
 	constructor() {
 		afterEveryRender(() => {
 			const element = this.elementRef.nativeElement;
-			// Update signals after render (host classes and innerHTML can be updated by bindings).
-			const currentLabel = (element.innerHTML || '').trim();
+			// textContent (not innerHTML): default labels are plain text, like Material viewValue.
+			const currentLabel = (element.textContent || '').trim();
 			if (currentLabel !== this.label()) {
 				this.label.set(currentLabel);
 			}

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -26,7 +26,7 @@
 							(keydown)="handleRemoveKeydown($event, item)"
 							>×</span
 						>
-						<span class="ng-value-label" [ngItemLabel]="item.label" [escape]="escapeHTML"></span>
+						<span class="ng-value-label">{{ item.label }}</span>
 					</ng-template>
 					<ng-template
 						[ngTemplateOutlet]="labelTemplate() || defaultLabelTemplate"
@@ -145,7 +145,7 @@
 					[attr.aria-setsize]="itemsList.filteredItems.length"
 					[attr.aria-posinset]="itemsList.filteredItems.indexOf(item) + 1 || null">
 					<ng-template #defaultOptionTemplate>
-						<span class="ng-option-label" [ngItemLabel]="item.label" [escape]="escapeHTML"></span>
+						<span class="ng-option-label">{{ item.label }}</span>
 					</ng-template>
 					<ng-template
 						[ngTemplateOutlet]="item.children ? optgroupTemplate() || defaultOptionTemplate : optionTemplate() || defaultOptionTemplate"

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -1187,6 +1187,25 @@ describe('NgSelectComponent', () => {
 		});
 
 		describe('ng-option', () => {
+			it('should not render HTML from unknown ngModel when using ng-option', async () => {
+				const fixture = createTestingModule(
+					NgSelectTestComponent,
+					`<ng-select [(ngModel)]="selectedCityId">
+						<ng-option [value]="1">Yes</ng-option>
+						<ng-option [value]="2">No</ng-option>
+					</ng-select>`,
+				);
+				await tickAndDetectChanges(fixture);
+
+				fixture.componentInstance.selectedCityId = `<img src="x" onerror="window.__xss2374=1">` as any;
+				await tickAndDetectChanges(fixture);
+
+				const labelEl = document.querySelector('.ng-value-label') as HTMLElement;
+				expect(labelEl).toBeTruthy();
+				expect(labelEl.querySelector('img')).toBeNull();
+				expect(labelEl.textContent).toContain('<img');
+			});
+
 			it('should reset to empty array', async () => {
 				const fixture = createTestingModule(
 					NgSelectTestComponent,

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -53,7 +53,6 @@ import {
 	NgClearButtonTemplateDirective,
 	NgFooterTemplateDirective,
 	NgHeaderTemplateDirective,
-	NgItemLabelDirective,
 	NgLabelTemplateDirective,
 	NgLoadingSpinnerTemplateDirective,
 	NgLoadingTextTemplateDirective,
@@ -138,7 +137,7 @@ class NgSelectAppendToOverlayContainer extends OverlayContainer {
 	],
 	encapsulation: ViewEncapsulation.None,
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	imports: [NgClass, NgTemplateOutlet, NgItemLabelDirective, NgDropdownPanelComponent],
+	imports: [NgClass, NgTemplateOutlet, NgDropdownPanelComponent],
 	host: {
 		'[class.ng-select]': 'true',
 		'[class.ng-select-single]': '!multiple()',
@@ -417,7 +416,6 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	/** Width of the notched-outline gap for the floated label in the material outline appearance */
 	readonly outlineNotchWidth = signal(0);
 	// variables
-	escapeHTML = true;
 	itemsList: ItemsList;
 	viewPortItems: NgOption[] = [];
 	tabFocusOnClear = signal<boolean>(true);
@@ -567,7 +565,6 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 	ngAfterViewInit() {
 		if (!this._itemsAreUsed) {
-			this.escapeHTML = false;
 			this._setItemsFromNgOptions();
 		}
 
@@ -1087,7 +1084,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 				this.bindLabel.set(this._defaultLabel);
 				const items = options.map((option) => ({
 					$ngOptionValue: option.value(),
-					$ngOptionLabel: option.elementRef.nativeElement.innerHTML,
+					$ngOptionLabel: option.label(),
 					$ngOptionClasses: option.classes(),
 					disabled: option.disabled(),
 				}));

--- a/src/ng-select/lib/ng-templates.directive.ts
+++ b/src/ng-select/lib/ng-templates.directive.ts
@@ -1,6 +1,10 @@
 import { Directive, effect, ElementRef, inject, input, TemplateRef } from '@angular/core';
-import { escapeHTML } from './value-utils';
 
+/**
+ * @deprecated Default labels are plain text via interpolation. Prefer `{{ label }}` or
+ * custom templates (`ng-label-tmp` / `ng-option-tmp`) for rich markup. Kept for public API
+ * compatibility; always writes `textContent` (the `escape` input is ignored).
+ */
 @Directive({
 	selector: '[ngItemLabel]',
 	standalone: true,
@@ -9,11 +13,12 @@ export class NgItemLabelDirective {
 	private element = inject<ElementRef<HTMLElement>>(ElementRef);
 
 	ngItemLabel = input<string>();
+	/** @deprecated Ignored — labels are always written as text. */
 	escape = input(true);
 
 	constructor() {
 		effect(() => {
-			this.element.nativeElement.innerHTML = this.escape() ? escapeHTML(this.ngItemLabel()) : this.ngItemLabel();
+			this.element.nativeElement.textContent = this.ngItemLabel() ?? '';
 		});
 	}
 }

--- a/src/ng-select/lib/value-utils.ts
+++ b/src/ng-select/lib/value-utils.ts
@@ -1,17 +1,3 @@
-const unescapedHTMLExp = /[&<>"']/g;
-const hasUnescapedHTMLExp = RegExp(unescapedHTMLExp.source);
-const htmlEscapes = {
-	'&': '&amp;',
-	'<': '&lt;',
-	'>': '&gt;',
-	'"': '&quot;',
-	"'": '&#39;',
-};
-
-export function escapeHTML(value: string) {
-	return value && hasUnescapedHTMLExp.test(value) ? value.replace(unescapedHTMLExp, (chr) => htmlEscapes[chr]) : value;
-}
-
 export function isDefined(value: any) {
 	return value !== undefined && value !== null;
 }


### PR DESCRIPTION
## Summary
- Treat default selected/option labels as plain text (Material / MUI / React Select model) so untrusted `ngModel` values cannot execute via `innerHTML` when using `<ng-option>`.
- Capture `<ng-option>` labels with `textContent`, stop flipping a global `escapeHTML = false`, and keep rich HTML on existing `ng-label-tmp` / `ng-option-tmp` templates.
- Add a regression test for unknown HTML `ngModel` with `<ng-option>` (fixes / addresses #2374).

**Breaking change:** HTML markup inside `<ng-option>` no longer renders as HTML (shows as text). Use label/option templates for rich markup. `NgItemLabelDirective` is deprecated and always writes `textContent`.

## Test plan
- [x] `pnpm exec ng test ng-select --watch=false` (456 passed)
- [ ] Manually: `<ng-option>` + `ngModel` set to `` `<img src=x onerror=…>` `` → shows as text, no `<img>` DOM
- [ ] Manually: `[items]` with HTML-looking labels still display as text
- [ ] Manually: `ng-label-tmp` / `ng-option-tmp` still allow rich markup


Made with [Cursor](https://cursor.com)