### PR TITLE
feat: backport changes from 24.0.0

### DIFF
--- a/.github/RELEASE_NOTES_v23.10.0.md
+++ b/.github/RELEASE_NOTES_v23.10.0.md
@@ -1,0 +1,41 @@
+# 23.10.0 (rollback)
+
+Restores a safe **23.x** line after **23.7.0–23.9.0** shipped the CDK Overlay migration (and related work) as minors. Those versions remain on npm but are superseded for `^23` by this release.
+
+**Base:** [v23.6.0](https://github.com/ng-select/ng-select/releases/tag/v23.6.0)  
+**Intent:** same pre-Overlay behavior as 23.6, plus a few small non-breaking fixes backported from 23.9.
+
+> Prefer **24.0.0** if you want Overlay, CSS-variable theming, typeahead/Escape behavior updates, and the full virtual-scroll improvements. See the 24.0.0 release notes for breaking changes.
+
+## Why this release
+
+| Version | Problem |
+| --- | --- |
+| 23.7.0 | Introduced CDK Overlay (breaking) as a minor |
+| 23.8.0 | CSS-variable theming (moved to 24.0.0) |
+| 23.9.0 | More Overlay-tied fixes + behavioral typeahead/Escape changes |
+
+**23.10.0 > 23.9.0**, so `npm install @ng-select/ng-select@^23` resolves here instead of 23.7–23.9.
+
+## Included (safe backports from 23.9)
+
+| Issue | Fix |
+| --- | --- |
+| [#2517](https://github.com/ng-select/ng-select/issues/2517) | Disabled select / disabled items cannot be removed via × or `clearItem` |
+| [#2549](https://github.com/ng-select/ng-select/issues/2549) | Skip `preventDefault` during Angular event replay (SSR/hydration) |
+| [#2669](https://github.com/ng-select/ng-select/issues/2669) | Allow copy/select of selected label when `searchable=false` |
+| [#1475](https://github.com/ng-select/ng-select/issues/1475) | Virtual scroll measures option height with `offsetHeight` (includes borders) |
+
+## Explicitly **not** included (ship in 24.0.0)
+
+- CDK Overlay dropdown / `@angular/cdk` peer / `appendTo`·`popover` / z-index changes ([#2848](https://github.com/ng-select/ng-select/pull/2848))
+- CSS-variable theming ([#2850](https://github.com/ng-select/ng-select/pull/2850))
+- Typeahead emit-on-typing-only contract ([#1504](https://github.com/ng-select/ng-select/issues/1504))
+- Escape `preventDefault` only when open ([#2849](https://github.com/ng-select/ng-select/issues/2849))
+- Variable group/option heights + empty→items panel sync ([#2762](https://github.com/ng-select/ng-select/issues/2762), [#2744](https://github.com/ng-select/ng-select/issues/2744))
+
+## Upgrade notes
+
+- From **23.6.0**: safe to take 23.10.0 (bugfixes only).
+- From **23.7–23.9**: pin `23.10.0` to leave Overlay, **or** move to **24.0.0** and follow its breaking-change guide.
+- No new peer dependencies vs 23.6.0 (still no `@angular/cdk` on this line).

--- a/.github/RELEASE_NOTES_v24.0.0.md
+++ b/.github/RELEASE_NOTES_v24.0.0.md
@@ -1,0 +1,69 @@
+# 24.0.0
+
+Major release consolidating work incorrectly shipped as **23.7.0–23.9.0** minors, plus intentional breaking/behavior changes. Use **[23.10.0](.github/RELEASE_NOTES_v23.10.0.md)** if you need a safe `^23` line without Overlay.
+
+**Compare:** from [v23.6.0](https://github.com/ng-select/ng-select/releases/tag/v23.6.0) / [v23.10.0](https://github.com/ng-select/ng-select/releases/tag/v23.10.0) → 24.0.0
+
+---
+
+## Breaking changes
+
+### 1. Dropdown panel renders in Angular CDK Overlay ([#2848](https://github.com/ng-select/ng-select/pull/2848))
+
+| Change | Before (≤23.6 / 23.10) | After (24.0) |
+| --- | --- | --- |
+| **DOM location** | Panel child of `<ng-select>` (unless `appendTo`) | CDK overlay (typically `.cdk-overlay-container`) |
+| **CSS scoping** | `.my-wrapper ng-dropdown-panel { … }` | Scope via select classes: `.my-select-class.ng-dropdown-panel …` |
+| **Peer** | No CDK | **`@angular/cdk` `^22.0.0` required** |
+| **`z-index: 1050`** | Hardcoded on panel | Removed; top layer in evergreen browsers; fallback ~1000 on `.cdk-overlay-container` |
+| **`appendTo`** | DOM parent + positioning | DOM containment only; positioning stays viewport-based |
+| **`popover`** | Opt-in | Deprecated no-op (top layer automatic) |
+| **Custom themes** | Often set `top`/`bottom`/`left` on panel | Remove positional offsets from forked themes |
+
+```bash
+pnpm add @ng-select/ng-select@24 @angular/cdk
+```
+
+Issues addressed by Overlay: [#2788](https://github.com/ng-select/ng-select/issues/2788), [#2829](https://github.com/ng-select/ng-select/issues/2829), [#2687](https://github.com/ng-select/ng-select/issues/2687), [#2575](https://github.com/ng-select/ng-select/issues/2575), [#2571](https://github.com/ng-select/ng-select/issues/2571), [#2092](https://github.com/ng-select/ng-select/issues/2092).
+
+### 2. Behavioral breaks
+
+| Area | Change | Action |
+| --- | --- | --- |
+| **Typeahead** ([#1504](https://github.com/ng-select/ng-select/issues/1504)) | Emits on typing only; select/close/clear do not emit | Use `(close)` / `(clear)` |
+| **Escape** ([#2849](https://github.com/ng-select/ng-select/issues/2849)) | `preventDefault` only when closing an open dropdown | Parent dialogs can receive Escape when select is closed |
+
+---
+
+## Features
+
+- **CSS-variable theming** ([#2850](https://github.com/ng-select/ng-select/pull/2850)) — themes expose CSS custom properties; styling docs + demo ([#2375](https://github.com/ng-select/ng-select/issues/2375), [#2452](https://github.com/ng-select/ng-select/issues/2452))
+- **Variable virtual-scroll heights** — separate option vs group header heights ([#2762](https://github.com/ng-select/ng-select/issues/2762))
+- **Non-searchable copy** ([#2669](https://github.com/ng-select/ng-select/issues/2669)) — also in 23.10.0
+
+---
+
+## Bug fixes
+
+| Issue | Fix | Also in 23.10? |
+| --- | --- | --- |
+| [#2517](https://github.com/ng-select/ng-select/issues/2517) | Disabled × / `clearItem` ignored | Yes |
+| [#2549](https://github.com/ng-select/ng-select/issues/2549) | Event replay `preventDefault` | Yes |
+| [#2669](https://github.com/ng-select/ng-select/issues/2669) | Copy selected label when not searchable | Yes |
+| [#1475](https://github.com/ng-select/ng-select/issues/1475) | `offsetHeight` includes borders | Yes |
+| [#1504](https://github.com/ng-select/ng-select/issues/1504) | Typeahead emit contract | No (breaking) |
+| [#2849](https://github.com/ng-select/ng-select/issues/2849) | Escape only when open | No (breaking) |
+| [#2762](https://github.com/ng-select/ng-select/issues/2762) | groupBy + custom template heights | No (Overlay-tied) |
+| [#2744](https://github.com/ng-select/ng-select/issues/2744) | typeahead empty→items keyboard scroll | No (Overlay-tied) |
+
+---
+
+## Relationship to 23.7–23.9 and 23.10
+
+| Version | Role |
+| --- | --- |
+| 23.7–23.9 | Accidental minors; avoid for new installs |
+| **23.10.0** | Rollback `^23` line = 23.6 + small safe fixes |
+| **24.0.0** | Correct major: Overlay + theming + remaining fixes |
+
+If you already run 23.7–23.9 in production, treat **24.0.0** as the supported upgrade path and follow the Breaking changes section above.


### PR DESCRIPTION
## Summary
- Adds release notes for **23.10.0** (safe `^23` rollback) and **24.0.0** (breaking Overlay major).
- Does **not** revert master — Overlay, CSS-variable theming, and 23.9 fixes stay for **24.0.0**.

## Release plan
| Version | Branch / source | Contents |
| --- | --- | --- |
| **23.10.0** | [`publish/23.10.0`](https://github.com/js-smart/ng-select/tree/publish/23.10.0) (from `v23.6.0` + `#2517` `#2549` `#2669` `#1475`) | Safe `^23` line; publish from that branch |
| **24.0.0** | `master` (this PR’s base) | Full Overlay + theming + remaining changes |

## Why the PR changed
Merging the original `release/23.10.0` (23.6-based) into `master` would have wiped Overlay. Conflicts are resolved by keeping **master’s code** and only adding the notes. Use `publish/23.10.0` to cut the 23.10.0 npm release.

## Test plan
- [ ] Confirm master still has CDK Overlay / `@angular/cdk` peer after merge
- [ ] Publish **23.10.0** from `publish/23.10.0` (not from master)
- [ ] Then release **24.0.0** from master using `.github/RELEASE_NOTES_v24.0.0.md`