### PR TITLE
feat: release 23.11.0 safe line (merge into master)

### DIFF
--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -399,7 +399,8 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges {
 			if (!option) {
 				return this._panelService.dimensions;
 			}
-			const optionHeight = option.clientHeight;
+			// offsetHeight includes borders; clientHeight does not (#1475).
+			const optionHeight = option.offsetHeight;
 			this._virtualPadding().style.height = `${optionHeight * this.itemsLength}px`;
 			const panelHeight = this._scrollablePanel().clientHeight;
 			this._panelService.setDimensions(optionHeight, panelHeight);

--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -31,6 +31,14 @@
 		}
 	}
 
+	// When search is disabled the input is still present for focus/ARIA, but it must not
+	// intercept clicks intended for the selected value (text selection / copy).
+	&:not(.ng-select-searchable) {
+		.ng-select-container .ng-value-container .ng-input {
+			pointer-events: none;
+		}
+	}
+
 	&.ng-select-opened .ng-select-container {
 		z-index: 1001;
 	}

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -1,5 +1,6 @@
 import { NgClass } from '@angular/common';
 import { Component, DebugElement, ErrorHandler, Type, viewChild, ViewEncapsulation } from '@angular/core';
+import { EventPhase } from '@angular/core/primitives/event-dispatch';
 import { SIGNAL } from '@angular/core/primitives/signals';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
@@ -5536,6 +5537,163 @@ describe('NgSelectComponent', () => {
 				triggerMousedown();
 				await tickAndDetectChanges(fixture);
 				expect(preventDefault).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('selected value text selection when not searchable (#2669)', () => {
+			beforeEach(async () => {
+				fixture = createTestingModule(
+					NgSelectTestComponent,
+					`<ng-select [items]="cities"
+                            bindLabel="name"
+                            [searchable]="false"
+                            [(ngModel)]="selectedCity">
+                    </ng-select>`,
+				);
+				select = fixture.componentInstance.select();
+				fixture.componentInstance.selectedCity = fixture.componentInstance.cities[0];
+				await tickAndDetectChanges(fixture);
+			});
+
+			it('should not preventDefault on mousedown of selected value label', async () => {
+				const label = fixture.debugElement.query(By.css('.ng-value-label')).nativeElement as HTMLElement;
+				const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 });
+				label.dispatchEvent(event);
+				await tickAndDetectChanges(fixture);
+				expect(event.defaultPrevented).toBe(false);
+			});
+
+			it('should not toggle dropdown when mousedown is on selected value label', async () => {
+				expect(select.isOpen()).toBe(false);
+				const label = fixture.debugElement.query(By.css('.ng-value-label')).nativeElement as HTMLElement;
+				label.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 }));
+				await tickAndDetectChanges(fixture);
+				expect(select.isOpen()).toBe(false);
+			});
+
+			it('should still toggle dropdown when mousedown is on arrow', async () => {
+				const arrow = fixture.debugElement.query(By.css('.ng-arrow-wrapper')).nativeElement as HTMLElement;
+				arrow.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 }));
+				await tickAndDetectChanges(fixture);
+				expect(select.isOpen()).toBe(true);
+			});
+
+			it('should ignore pointer events on .ng-input when not searchable', async () => {
+				const ngInput = fixture.debugElement.query(By.css('.ng-input')).nativeElement as HTMLElement;
+				expect(getComputedStyle(ngInput).pointerEvents).toBe('none');
+			});
+		});
+
+		describe('event replay (#2549)', () => {
+			beforeEach(async () => {
+				fixture = createTestingModule(
+					NgSelectTestComponent,
+					`<ng-select [items]="cities"
+                            bindLabel="name"
+                            [(ngModel)]="selectedCity">
+                    </ng-select>`,
+				);
+				select = fixture.componentInstance.select();
+				await tickAndDetectChanges(fixture);
+			});
+
+			it('should not call preventDefault during Angular event replay', async () => {
+				const event = {
+					...createEvent({ tagName: 'DIV', className: 'ng-control' }),
+					eventPhase: EventPhase.REPLAY,
+				} as any;
+				const preventDefault = vi.spyOn(event, 'preventDefault').mockImplementation(() => {
+					throw new Error('`preventDefault` called during event replay.');
+				});
+
+				const control = fixture.debugElement.query(By.css('.ng-select-container'));
+				expect(() => control.triggerEventHandler('mousedown', event)).not.toThrow();
+				await tickAndDetectChanges(fixture);
+
+				expect(preventDefault).not.toHaveBeenCalled();
+				expect(select.isOpen()).toBe(true);
+			});
+
+			it('should call preventDefault for normal (non-replay) mousedown', async () => {
+				const event = createEvent({ tagName: 'DIV', className: 'ng-control' }) as any;
+				const preventDefault = vi.spyOn(event, 'preventDefault').mockReturnValue(undefined);
+
+				const control = fixture.debugElement.query(By.css('.ng-select-container'));
+				control.triggerEventHandler('mousedown', event);
+				await tickAndDetectChanges(fixture);
+
+				expect(preventDefault).toHaveBeenCalled();
+				expect(select.isOpen()).toBe(true);
+			});
+		});
+
+		describe('disabled unselect (#2517)', () => {
+			it('should ignore unselect when the select is disabled', async () => {
+				const fixture = createTestingModule(
+					NgSelectTestComponent,
+					`<ng-select [items]="cities" bindLabel="name" [multiple]="true" [disabled]="true" [(ngModel)]="selectedCities"></ng-select>`,
+				);
+				fixture.componentInstance.selectedCities = [fixture.componentInstance.cities[0], fixture.componentInstance.cities[1]];
+				await tickAndDetectChanges(fixture);
+				await tickAndDetectChanges(fixture);
+
+				const select = fixture.componentInstance.select();
+				const removeEmit = vi.spyOn(select.removeEvent, 'emit');
+				select.unselect(select.selectedItems[0]);
+				await tickAndDetectChanges(fixture);
+
+				expect(select.selectedItems.length).toBe(2);
+				expect(removeEmit).not.toHaveBeenCalled();
+			});
+
+			it('should ignore unselect when the item is disabled', async () => {
+				const fixture = createTestingModule(
+					NgSelectTestComponent,
+					`<ng-select [items]="cities" bindLabel="name" [multiple]="true" [(ngModel)]="selectedCities"></ng-select>`,
+				);
+				fixture.componentInstance.selectedCities = [fixture.componentInstance.cities[0], fixture.componentInstance.cities[1]];
+				await tickAndDetectChanges(fixture);
+				await tickAndDetectChanges(fixture);
+
+				const select = fixture.componentInstance.select();
+				select.selectedItems[0].disabled = true;
+				const removeEmit = vi.spyOn(select.removeEvent, 'emit');
+				select.unselect(select.selectedItems[0]);
+				await tickAndDetectChanges(fixture);
+
+				expect(select.selectedItems.length).toBe(2);
+				expect(removeEmit).not.toHaveBeenCalled();
+			});
+
+			it('should ignore the remove icon click when the select is disabled', async () => {
+				const fixture = createTestingModule(
+					NgSelectTestComponent,
+					`<ng-select [items]="cities" bindLabel="name" [multiple]="true" [disabled]="true" [(ngModel)]="selectedCities"></ng-select>`,
+				);
+				fixture.componentInstance.selectedCities = [fixture.componentInstance.cities[0], fixture.componentInstance.cities[1]];
+				await tickAndDetectChanges(fixture);
+				await tickAndDetectChanges(fixture);
+
+				fixture.debugElement.query(By.css('.ng-value-icon')).triggerEventHandler('click', {});
+				await tickAndDetectChanges(fixture);
+
+				expect(fixture.componentInstance.select().selectedItems.length).toBe(2);
+			});
+
+			it('should ignore clearItem when the select is disabled', async () => {
+				const fixture = createTestingModule(
+					NgSelectTestComponent,
+					`<ng-select [items]="cities" bindLabel="name" [multiple]="true" [disabled]="true" [(ngModel)]="selectedCities"></ng-select>`,
+				);
+				fixture.componentInstance.selectedCities = [fixture.componentInstance.cities[0], fixture.componentInstance.cities[1]];
+				await tickAndDetectChanges(fixture);
+				await tickAndDetectChanges(fixture);
+
+				const select = fixture.componentInstance.select();
+				select.clearItem(select.selectedItems[0].value);
+				await tickAndDetectChanges(fixture);
+
+				expect(select.selectedItems.length).toBe(2);
 			});
 		});
 

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -31,6 +31,7 @@ import {
 	viewChild,
 	ViewEncapsulation,
 } from '@angular/core';
+import { EventPhase } from '@angular/core/primitives/event-dispatch';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { debounceTime, filter, map, tap } from 'rxjs/operators';
@@ -521,7 +522,22 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			return false;
 		}
 		const target = $event.target as HTMLElement;
-		if (target.tagName !== 'INPUT') {
+
+		// Allow highlighting/copying the selected label when search is disabled.
+		// Skipping preventDefault + toggle lets the browser start a text selection.
+		// See https://github.com/ng-select/ng-select/issues/2669
+		const onSelectedValue = !!target.closest?.('.ng-value');
+		const onValueIcon = target.classList.contains('ng-value-icon') || !!target.closest?.('.ng-value-icon');
+		if (!this.searchable() && onSelectedValue && !onValueIcon) {
+			if (!this._focused) {
+				this.focus();
+			}
+			return;
+		}
+
+		// Skip during Angular event replay (SSR hydration): preventDefault has no effect
+		// after browser dispatch and throws — see https://github.com/ng-select/ng-select/issues/2549
+		if (target.tagName !== 'INPUT' && $event.eventPhase !== EventPhase.REPLAY) {
 			$event.preventDefault();
 		}
 
@@ -687,7 +703,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	}
 
 	unselect(item: NgOption) {
-		if (!item) {
+		if (!item || this.disabled() || item.disabled) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Updates **remote `master`** to the safe **23.11.0** line (pre-Overlay + safe backports).

1. **Revert** CDK Overlay, CSS-variable theming, and mistaken 23.7–23.10 work back to `v23.6.0`
2. **Re-apply** only safe fixes: #2517, #2549, #2669, #1475

Local maintainer `master` (with 24.0.0 / Overlay work) is **unchanged** and can fast-forward remote later.

## Explicitly excluded

- CDK Overlay / `@angular/cdk` peer
- CSS-variable theming
- Typeahead emit-on-typing-only
- Escape `preventDefault` only when open

## After merge

Release workflow should publish **23.11.0** (synthetic tag `v23.10.99` is on `v23.6.0` so semver jumps past the bad Overlay minors).

## Test plan

- [ ] CI green
- [ ] Merge to `master`
- [ ] Confirm npm `@ng-select/ng-select@23.11.0` has **no** `@angular/cdk` peer