### PR TITLE
fix: fixes signal forms issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ import { FormField } from '@angular/forms/signals';
 @Component({
 	selector: 'example',
 	standalone: true,
-	template: './example.component.html',
+	templateUrl: './example.component.html',
 	styleUrl: './example.component.scss',
 	imports: [FormField, NgLabelTemplateDirective, NgOptionTemplateDirective, NgSelectComponent],
 })

--- a/angular.json
+++ b/angular.json
@@ -162,7 +162,10 @@
 				"serve": {
 					"builder": "@ng-doc/builder:dev-server",
 					"options": {
-						"buildTarget": "demo:build"
+						"buildTarget": "demo:build",
+						"ngDoc": {
+							"config": "src/demo/ng-doc.serve.config.ts"
+						}
 					},
 					"configurations": {
 						"production": {

--- a/src/demo/app/examples/forms-signal-example/forms-signal-example.component.html
+++ b/src/demo/app/examples/forms-signal-example/forms-signal-example.component.html
@@ -24,9 +24,12 @@
 	@if (cityForm.cityIds().touched() && cityForm.cityIds().invalid()) {
 		<small class="text-danger">{{ cityForm.cityIds().errors()[0].message }}</small>
 	}
-	<p class="form-text text-muted">The form starts with selected IDs before the async item list arrives. Hiding and showing the control preserves them.</p>
+	<p class="form-text text-muted">
+		The form starts with two selected IDs before the item list exists. Load the items to see them mapped to options, and hide/show the control to see the
+		values preserved.
+	</p>
 	<button type="button" class="btn btn-sm btn-secondary" (click)="loadCities()">Load items</button>
-	<button type="button" class="btn btn-sm btn-secondary" (click)="clearCities()">Clear</button>
+	<button type="button" class="btn btn-sm btn-secondary" (click)="clearCities()">Reset demo</button>
 	<button type="button" class="btn btn-sm btn-secondary" (click)="toggleMultipleVisible()">Show/Hide</button>
 </div>
 

--- a/src/demo/app/examples/forms-signal-example/forms-signal-example.component.ts
+++ b/src/demo/app/examples/forms-signal-example/forms-signal-example.component.ts
@@ -1,5 +1,5 @@
 import { JsonPipe } from '@angular/common';
-import { afterNextRender, ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { disabled, form, FormField, minLength, required } from '@angular/forms/signals';
 import { NgSelectComponent } from '@ng-select/ng-select';
 
@@ -33,19 +33,16 @@ export class FormsSignalExampleComponent {
 	readonly cityForm = form(this.model, (path) => {
 		required(path.cityId, { message: 'Choose a city' });
 		minLength(path.cityIds, 1, { message: 'Choose at least one city' });
-		disabled(path.cityId, () => this.cityDisabled());
+		disabled(path.cityId, { when: () => this.cityDisabled() });
 	});
 
-	constructor() {
-		afterNextRender(() => this.loadCities());
-	}
-
 	loadCities(): void {
-		this.asyncCities.set(this.cities);
+		this.asyncCities.set([...this.cities]);
 	}
 
 	clearCities(): void {
-		this.cityForm.cityIds().value.set([]);
+		this.asyncCities.set([]);
+		this.cityForm.cityIds().value.set([1, 3]);
 	}
 
 	toggleCityDisabled(): void {

--- a/src/demo/ng-doc.config.ts
+++ b/src/demo/ng-doc.config.ts
@@ -1,9 +1,9 @@
 import { NgDocConfiguration } from '@ng-doc/builder';
 
 const config: NgDocConfiguration = {
-	// Keep output between rebuilds so Angular's watcher does not compile while ng-doc/demo is deleted.
-	// Tradeoff: a cold start with a warm cache may skip page indexing until a doc file changes.
-	cache: true,
+	// Keep the cache off: warm-cache builds skip page indexing and ship an empty search index.
+	// `ng serve` uses ng-doc.serve.config.ts instead (wired via `ngDoc.config` in angular.json).
+	cache: false,
 	repoConfig: {
 		url: 'https://github.com/ng-select/ng-select',
 		mainBranch: 'master',

--- a/src/demo/ng-doc.serve.config.ts
+++ b/src/demo/ng-doc.serve.config.ts
@@ -1,0 +1,14 @@
+import { NgDocConfiguration } from '@ng-doc/builder';
+import baseConfig from './ng-doc.config';
+
+/**
+ * Dev-server-only Ng-Doc config (see the demo `serve` target in angular.json).
+ * Production builds keep using ng-doc.config.ts, where the cache stays off so the search index is always populated.
+ */
+const config: NgDocConfiguration = {
+	...baseConfig,
+	// Keep output between rebuilds so Angular's watcher does not compile while ng-doc/demo is deleted.
+	cache: true,
+};
+
+export default config;

--- a/src/ng-select/lib/items-list.ts
+++ b/src/ng-select/lib/items-list.ts
@@ -384,6 +384,9 @@ export class ItemsList {
 		if (!isObject(option)) {
 			return option;
 		}
+		if (!key) {
+			return undefined;
+		}
 		if (key.indexOf('.') === -1) {
 			return option[key];
 		} else {
@@ -442,6 +445,10 @@ export class ItemsList {
 			}
 
 			this._selectionModel.unselect(selected, multiple);
+			if (item?.selected) {
+				// Already re-selected by an earlier iteration (duplicate value); drop the placeholder only
+				continue;
+			}
 			this._selectionModel.select(item || selected, multiple, this._ngSelect.selectableGroupAsModel());
 		}
 

--- a/src/ng-select/lib/ng-select/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select/ng-select.component.ts
@@ -412,6 +412,8 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	private _manualOpen: boolean;
 	private _pressedKeys: string[] = [];
 	private _primitive: any;
+	/** Last value written via `writeValue` or emitted via `_updateNgModel`; re-applied when mode/bindings change. */
+	private _lastWrittenValue: any | any[] = null;
 	private readonly _searchTerm = signal<string>(null);
 	private readonly _validTerm = computed(() => {
 		const term = this._searchTerm()?.trim();
@@ -870,6 +872,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	 * @since 3.0.0
 	 */
 	writeValue(value: any | any[]): void {
+		this._lastWrittenValue = value;
 		this.itemsList.clearSelected(false);
 		this._handleWriteValue(value);
 		if (this._editableSearchTermActive()) {
@@ -1297,7 +1300,34 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 					return;
 				}
 
-				untracked(() => this.itemsList.clearSelected(false));
+				untracked(() => {
+					const written = this._lastWrittenValue;
+					this._resyncSelectionFromWrittenValue();
+					const hadValue = isDefined(written) && !(Array.isArray(written) && written.length === 0);
+					if (hadValue && !this.hasValue) {
+						// The retained value cannot be represented in the new mode; emit the cleared value
+						// so the form model and the UI stay in sync
+						this._updateNgModel();
+					}
+				});
+			},
+			{ injector: this._injector },
+		);
+
+		// Re-map the retained form value when the value binding or comparator changes.
+		// bindLabel is intentionally not tracked: _setItems writes it and would loop.
+		let bindingsInitialized = false;
+		effect(
+			() => {
+				this.bindValue();
+				this.compareWith();
+
+				if (!bindingsInitialized) {
+					bindingsInitialized = true;
+					return;
+				}
+
+				untracked(() => this._resyncSelectionFromWrittenValue());
 			},
 			{ injector: this._injector },
 		);
@@ -1356,6 +1386,20 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 	private _setSearchTermFromItems() {
 		const selected = this.selectedItems?.[0];
 		this._searchTerm.set(selected?.label ?? null);
+	}
+
+	/**
+	 * Re-applies the last written form value against the current mode and bindings.
+	 *
+	 * @since 24.0.5
+	 */
+	private _resyncSelectionFromWrittenValue() {
+		this.itemsList.clearSelected(false);
+		this._handleWriteValue(this._lastWrittenValue);
+		if (this._editableSearchTermActive()) {
+			this._setSearchTermFromItems();
+		}
+		this._cd.markForCheck();
 	}
 
 	/**
@@ -1453,7 +1497,7 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 			if (item) {
 				this.itemsList.select(item);
 			} else {
-				item = createUnmatchedOptionValue(val, this.bindLabel(), this.bindValue());
+				item = createUnmatchedOptionValue(val, this.bindLabel() || this._defaultLabel, this.bindValue());
 				this.itemsList.select(this.itemsList.mapItem(item, null));
 			}
 		};
@@ -1549,10 +1593,13 @@ export class NgSelectComponent implements OnChanges, OnInit, AfterViewInit, Cont
 
 		const selected = this.selectedItems.map((x) => x.value);
 		if (this.multiple()) {
+			this._lastWrittenValue = model;
 			this._onChange(model);
 			this.changeEvent.emit(selected);
 		} else {
-			this._onChange(isDefined(model[0]) ? model[0] : null);
+			const single = isDefined(model[0]) ? model[0] : null;
+			this._lastWrittenValue = single;
+			this._onChange(single);
 			this.changeEvent.emit(selected[0]);
 		}
 

--- a/src/ng-select/lib/ng-select/ng-select.signal-forms.spec.ts
+++ b/src/ng-select/lib/ng-select/ng-select.signal-forms.spec.ts
@@ -1,10 +1,12 @@
-import { Component, Provider, signal, Type, viewChild } from '@angular/core';
+import { Component, ErrorHandler, Provider, signal, Type, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { disabled, form, FormField, minLength, provideSignalFormsConfig, readonly, required } from '@angular/forms/signals';
+import { disabled, form, FormField, provideSignalFormsConfig, readonly, required } from '@angular/forms/signals';
 import { NG_STATUS_CLASSES } from '@angular/forms/signals/compat';
 import { describe, expect, it } from 'vitest';
-import { applyZonelessFixtureCompat } from '../../testing/helpers';
+import { applyZonelessFixtureCompat, TestsErrorHandler, tickAndDetectChanges } from '../../testing/helpers';
+import { MockConsole } from '../../testing/mocks';
 import { provideNgSelect } from '../ng-select.module';
+import { ConsoleService } from '../services/console.service';
 import { NgSelectComponent } from './ng-select.component';
 
 interface City {
@@ -29,26 +31,28 @@ const LABELED_OPTIONS: LabeledOption[] = [
 	{ id: 3, label: 'Three' },
 ];
 
+const settle = tickAndDetectChanges;
+
 async function createFixture<T>(component: Type<T>, providers: Provider[] = []): Promise<ComponentFixture<T>> {
-	TestBed.configureTestingModule({ providers: [...provideNgSelect(), ...providers] });
+	TestBed.configureTestingModule({
+		providers: [
+			{ provide: ErrorHandler, useClass: TestsErrorHandler },
+			{ provide: ConsoleService, useFactory: () => new MockConsole() },
+			...provideNgSelect(),
+			...providers,
+		],
+	});
 	const fixture = applyZonelessFixtureCompat(TestBed.createComponent(component));
 	await settle(fixture);
 	return fixture;
-}
-
-async function settle(fixture: ComponentFixture<unknown>): Promise<void> {
-	fixture.detectChanges();
-	await fixture.whenStable();
-	fixture.detectChanges();
-	await fixture.whenStable();
 }
 
 function selectedIds(select: NgSelectComponent): number[] {
 	return select.selectedItems.map((item) => item.value?.id ?? item.value);
 }
 
-function searchInput(fixture: ComponentFixture<unknown>): HTMLInputElement {
-	return fixture.nativeElement.querySelector('ng-select input');
+function blurSearchInput(select: NgSelectComponent): void {
+	select.searchInput().nativeElement.dispatchEvent(new FocusEvent('blur'));
 }
 
 @Component({
@@ -71,6 +75,15 @@ class SignalFormsSingleTestComponent {
 class SignalFormsExplicitSingleTestComponent extends SignalFormsSingleTestComponent {}
 
 @Component({
+	selector: 'ng-signal-forms-late-bind-value-test',
+	imports: [FormField, NgSelectComponent],
+	template: `<ng-select [items]="items()" bindLabel="name" [bindValue]="valueKey()" [formField]="cityForm.cityId" />`,
+})
+class SignalFormsLateBindValueTestComponent extends SignalFormsSingleTestComponent {
+	readonly valueKey = signal<string | undefined>(undefined);
+}
+
+@Component({
 	selector: 'ng-signal-forms-multiple-test',
 	imports: [FormField, NgSelectComponent],
 	template: `<ng-select [items]="items()" bindLabel="name" bindValue="id" [multiple]="multiple()" [formField]="cityForm.cityIds" />`,
@@ -78,7 +91,28 @@ class SignalFormsExplicitSingleTestComponent extends SignalFormsSingleTestCompon
 class SignalFormsMultipleTestComponent {
 	readonly items = signal<readonly City[]>(CITIES);
 	readonly multiple = signal(true);
-	readonly model = signal({ cityIds: [1, 3] as number[] });
+	readonly model = signal({ cityIds: [1, 3] as number[] | null });
+	readonly cityForm = form(this.model);
+	readonly select = viewChild.required(NgSelectComponent);
+}
+
+@Component({
+	selector: 'ng-signal-forms-late-multiple-test',
+	imports: [FormField, NgSelectComponent],
+	template: `<ng-select [items]="items()" bindLabel="name" bindValue="id" [multiple]="multiple()" [formField]="cityForm.cityIds" />`,
+})
+class SignalFormsLateMultipleTestComponent extends SignalFormsMultipleTestComponent {
+	override readonly multiple = signal(false);
+}
+
+@Component({
+	selector: 'ng-signal-forms-duplicate-value-test',
+	imports: [FormField, NgSelectComponent],
+	template: `<ng-select [items]="items()" bindLabel="name" bindValue="id" [multiple]="true" [formField]="cityForm.cityIds" />`,
+})
+class SignalFormsDuplicateValueTestComponent {
+	readonly items = signal<readonly City[]>(CITIES);
+	readonly model = signal({ cityIds: [1, 1] as number[] | null });
 	readonly cityForm = form(this.model);
 	readonly select = viewChild.required(NgSelectComponent);
 }
@@ -105,6 +139,15 @@ class SignalFormsAsyncSingleTestComponent {
 	readonly model = signal({ cityId: 2 as number | null });
 	readonly cityForm = form(this.model);
 	readonly select = viewChild.required(NgSelectComponent);
+}
+
+@Component({
+	selector: 'ng-signal-forms-late-bind-label-primitive-test',
+	imports: [FormField, NgSelectComponent],
+	template: `<ng-select [items]="items()" [bindLabel]="labelKey()" bindValue="id" [formField]="cityForm.cityId" />`,
+})
+class SignalFormsLateBindLabelPrimitiveTestComponent extends SignalFormsAsyncSingleTestComponent {
+	readonly labelKey = signal<string | undefined>(undefined);
 }
 
 @Component({
@@ -137,25 +180,35 @@ class SignalFormsObjectValueTestComponent {
 }
 
 @Component({
+	selector: 'ng-signal-forms-late-bind-label-object-test',
+	imports: [FormField, NgSelectComponent],
+	template: `<ng-select [items]="items()" [bindLabel]="labelKey()" [compareWith]="compareWith" [formField]="optionForm.option" />`,
+})
+class SignalFormsLateBindLabelObjectTestComponent {
+	readonly labelKey = signal<string | undefined>(undefined);
+	readonly items = signal<readonly LabeledOption[]>([]);
+	readonly compareWith = (a: LabeledOption | null, b: LabeledOption | null) => a?.id === b?.id;
+	readonly model = signal({ option: LABELED_OPTIONS[0] as LabeledOption | null });
+	readonly optionForm = form(this.model);
+	readonly select = viewChild.required(NgSelectComponent);
+}
+
+@Component({
 	selector: 'ng-signal-forms-state-test',
 	imports: [FormField, NgSelectComponent],
-	template: `
-		<ng-select [items]="items" bindLabel="name" bindValue="id" [formField]="cityForm.cityId" />
-		<ng-select [items]="items" bindLabel="name" bindValue="id" [multiple]="true" [formField]="cityForm.cityIds" />
-	`,
+	template: `<ng-select [items]="items" bindLabel="name" bindValue="id" [formField]="cityForm.cityId" />`,
 })
 class SignalFormsStateTestComponent {
 	readonly items = CITIES;
 	readonly disabledState = signal(false);
 	readonly readonlyState = signal(false);
-	readonly model = signal({ cityId: null as number | null, cityIds: [] as number[] });
+	readonly model = signal({ cityId: null as number | null });
 	readonly cityForm = form(this.model, (path) => {
 		required(path.cityId);
-		minLength(path.cityIds, 1);
-		disabled(path.cityId, () => this.disabledState());
-		readonly(path.cityId, () => this.readonlyState());
+		disabled(path.cityId, { when: () => this.disabledState() });
+		readonly(path.cityId, { when: () => this.readonlyState() });
 	});
-	readonly selects = viewChild.required(NgSelectComponent);
+	readonly select = viewChild.required(NgSelectComponent);
 }
 
 describe('NgSelectComponent Signal Forms', () => {
@@ -175,7 +228,7 @@ describe('NgSelectComponent Signal Forms', () => {
 		expect(component.model()).toEqual({ cityId: 1 });
 		expect(component.cityForm.cityId().dirty()).toBe(true);
 
-		searchInput(fixture).dispatchEvent(new Event('blur'));
+		blurSearchInput(component.select());
 		await settle(fixture);
 		expect(component.cityForm.cityId().touched()).toBe(true);
 
@@ -200,7 +253,7 @@ describe('NgSelectComponent Signal Forms', () => {
 		expect(selectedIds(fixture.componentInstance.select())).toEqual([1, 3]);
 	});
 
-	it('still clears the selection when multiple changes after initialization', async () => {
+	it('clears the selection and the form value when multiple turns off after initialization', async () => {
 		const fixture = await createFixture(SignalFormsMultipleTestComponent);
 		const component = fixture.componentInstance;
 		expect(selectedIds(component.select())).toEqual([1, 3]);
@@ -208,6 +261,24 @@ describe('NgSelectComponent Signal Forms', () => {
 		component.multiple.set(false);
 		await settle(fixture);
 		expect(component.select().selectedItems).toEqual([]);
+		expect(component.cityForm.cityIds().value()).toBeNull();
+		expect(component.model().cityIds).toBeNull();
+	});
+
+	it('keeps an initial multiple value written before multiple turns on', async () => {
+		const fixture = await createFixture(SignalFormsLateMultipleTestComponent);
+		const component = fixture.componentInstance;
+		expect(component.select().selectedItems).toEqual([]);
+
+		component.multiple.set(true);
+		await settle(fixture);
+		expect(selectedIds(component.select())).toEqual([1, 3]);
+		expect(component.cityForm.cityIds().value()).toEqual([1, 3]);
+	});
+
+	it('selects a duplicate bound value once', async () => {
+		const fixture = await createFixture(SignalFormsDuplicateValueTestComponent);
+		expect(selectedIds(fixture.componentInstance.select())).toEqual([1]);
 	});
 
 	it('remaps initial multiple values when items arrive asynchronously', async () => {
@@ -231,6 +302,17 @@ describe('NgSelectComponent Signal Forms', () => {
 		await settle(fixture);
 		expect(selectedIds(component.select())).toEqual([2]);
 		expect(component.select().selectedItems[0]).toBe(component.select().itemsList.items[1]);
+	});
+
+	it('remaps the written value when bindValue arrives later', async () => {
+		const fixture = await createFixture(SignalFormsLateBindValueTestComponent);
+		const component = fixture.componentInstance;
+
+		component.valueKey.set('id');
+		await settle(fixture);
+		expect(selectedIds(component.select())).toEqual([2]);
+		expect(component.select().selectedItems[0]).toBe(component.select().itemsList.items[1]);
+		expect(component.cityForm.cityId().value()).toBe(2);
 	});
 
 	it('restores initial multiple values whenever an @if recreates the control', async () => {
@@ -259,11 +341,36 @@ describe('NgSelectComponent Signal Forms', () => {
 		expect(component.select().selectedItems[1]).toBe(component.select().itemsList.items[2]);
 	});
 
+	describe('bindLabel bound to an initially undefined value (#2840)', () => {
+		it('does not crash when bindLabel is bound to an initially undefined value', async () => {
+			// Creating the fixture must not throw while bindLabel is still undefined.
+			const fixture = await createFixture(SignalFormsLateBindLabelObjectTestComponent);
+			const component = fixture.componentInstance;
+			expect(component.select().selectedItems.length).toBe(1);
+
+			component.labelKey.set('label');
+			component.items.set(LABELED_OPTIONS);
+			await settle(fixture);
+			expect(component.select().selectedItems[0]).toBe(component.select().itemsList.items[0]);
+		});
+
+		it('does not crash with a primitive bound value when bindLabel is initially undefined', async () => {
+			const fixture = await createFixture(SignalFormsLateBindLabelPrimitiveTestComponent);
+			const component = fixture.componentInstance;
+			expect(selectedIds(component.select())).toEqual([2]);
+
+			component.labelKey.set('name');
+			component.items.set(CITIES);
+			await settle(fixture);
+			expect(selectedIds(component.select())).toEqual([2]);
+		});
+	});
+
 	it('integrates validation, disabled, readonly, and configured status classes', async () => {
 		const fixture = await createFixture(SignalFormsStateTestComponent, [provideSignalFormsConfig({ classes: NG_STATUS_CLASSES })]);
 		const component = fixture.componentInstance;
-		const hosts = fixture.nativeElement.querySelectorAll('ng-select') as NodeListOf<HTMLElement>;
-		const firstInput = hosts[0].querySelector('input') as HTMLInputElement;
+		const host = fixture.nativeElement.querySelector('ng-select') as HTMLElement;
+		const input = component.select().searchInput().nativeElement;
 
 		expect(component.cityForm.cityId().invalid()).toBe(true);
 		expect(
@@ -272,29 +379,22 @@ describe('NgSelectComponent Signal Forms', () => {
 				.errors()
 				.map((error) => error.kind),
 		).toEqual(['required']);
-		expect(component.cityForm.cityIds().invalid()).toBe(true);
-		expect(
-			component.cityForm
-				.cityIds()
-				.errors()
-				.map((error) => error.kind),
-		).toEqual(['minLength']);
-		expect(hosts[0].classList.contains('ng-invalid')).toBe(true);
-		expect(hosts[0].classList.contains('ng-untouched')).toBe(true);
+		expect(host.classList.contains('ng-invalid')).toBe(true);
+		expect(host.classList.contains('ng-untouched')).toBe(true);
 
-		firstInput.dispatchEvent(new Event('blur'));
+		blurSearchInput(component.select());
 		await settle(fixture);
 		expect(component.cityForm.cityId().touched()).toBe(true);
-		expect(hosts[0].classList.contains('ng-touched')).toBe(true);
+		expect(host.classList.contains('ng-touched')).toBe(true);
 
 		component.disabledState.set(true);
 		await settle(fixture);
-		expect(firstInput.disabled).toBe(true);
+		expect(input.disabled).toBe(true);
 
 		component.disabledState.set(false);
 		component.readonlyState.set(true);
 		await settle(fixture);
-		expect(component.selects().readonly()).toBe(true);
-		expect(component.selects().disabled()).toBe(true);
+		expect(component.select().readonly()).toBe(true);
+		expect(component.select().disabled()).toBe(true);
 	});
 });


### PR DESCRIPTION
- Changed `template` to `templateUrl` in the example component decorator for consistency.
- Disabled caching in ng-doc configuration to ensure proper page indexing.
- Enhanced the forms-signal-example component's HTML and TypeScript for better user guidance and functionality, including clearer button labels and improved form handling.
- Added checks in the ItemsList class to handle undefined keys and prevent duplicate selections.
- Updated NgSelectComponent to maintain the last written value for better synchronization with form bindings.

Closes #2878